### PR TITLE
Improve docu on clouds & secure.yaml parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ on OpenStack instance previously provided by Terraform.
   (https://docs.openstack.org/python-openstackclient/latest/configuration/index.html#clouds-yaml)
 * place your ``clouds.yaml`` and your ``secure.yaml`` in the ``terraform`` folder. Examples are
   provided in ``clouds.yaml.sample`` and ``secure.yaml.sample``
+  Note that you need ``project_domain_name`` and ``username`` in ``clouds.yaml``.
+  (``username`` is normally only in ``secure.yaml`` and the ``project_domain_name`` is not
+  normally needed. Copy your ``user_domain_name`` setting in case you wonder what's needed here.)
 * Copy the environments sample file from environments/environment-default.tfvars to
   ``environments/environment-<yourcloud>.tfvars`` and provide the necessary information like
   machine flavor or machine image.
-* Set the Variable ``ENVIRONMENT`` in Makefile:4 to ``<yourcloud>``
+* Set the Variable ``ENVIRONMENT`` in Makefile:4 to ``<yourcloud>`` (or override by passing
+  ``ENVIRONMENT=`` in the ``make`` call).
 
 ## Usage
 
@@ -29,3 +33,5 @@ created cluster is named ``workload-cluster.yaml``.
 
 You can purge the whole project via ``make purge``. Be careful with that command it will purge
 all resources in the project even those that have not been created through this Terraform script.
+It requires the [``ospurge``](https://opendev.org/x/ospurge) script.
+``make clean`` is insufficient to clean up unfortunately.

--- a/terraform/clouds.yaml.sample
+++ b/terraform/clouds.yaml.sample
@@ -8,5 +8,8 @@ clouds:
       auth_url:
       project_name:
       user_domain_name:
+      # openstack does not necessarily need this, but the templates want it
       project_domain_name:
+      # this one is not normally in clouds.yaml, but the templates expect it
+      username:
     region_name:

--- a/terraform/secure.yaml.sample
+++ b/terraform/secure.yaml.sample
@@ -2,5 +2,6 @@
 clouds:
   example:
     auth:
+      # username needs to be in clouds.yaml (duplication is OK)
       username:
       password:


### PR DESCRIPTION
The templating mechanism is picky when validating the cloud.yaml
and secure.yaml, requiring more fields than is usual.
Document this.

Also document the use of ospurge.

Signed-off-by: Kurt Garloff <kurt@garloff.de>