### PR TITLE
Allow env vars to override ENVIRONMENT, USERNAME, OPENSTACK.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -2,12 +2,12 @@
 
 # set the env we used 
 #ENVIRONMENT = gx-betacloud
-ENVIRONMENT = gx-citycloud
+ENVIRONMENT ?= gx-citycloud
 #ENVIRONMENT = gx-scs
 SHELL=/bin/bash
 #ENVIRONMENT = gx-bc
-OPENSTACK = openstack
-USERNAME = ubuntu
+OPENSTACK ?= openstack
+USERNAME ?= ubuntu
 CONSOLE = capi-mgmtcluster
 
 # check for openstack credentials


### PR DESCRIPTION
This allows you to set the correct ENVIRONMENT in your .bashrc and you
don't need to pass ENVIRONMENT=xxx in every make call.