### PR TITLE
Upgrade default kubernetes version to 1.21.4.

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,7 +36,7 @@ variable "ssh_username" {
 variable "kubernetes_version" {
   description = "desired kubernetes version for the workload cluster"
   type        = string
-  default     = "v1.20.9"
+  default     = "v1.21.4"
 }
 
 variable "kind_mtu" {


### PR DESCRIPTION
As we have 1.21 in kind, we also upgrade the worker clusters. Tested successfully.

Signed-off-by: Kurt Garloff <scs@garloff.de>