### PR TITLE
Latest alpha3 cluster-api, latest k9s.

### DIFF
--- a/terraform/files/bootstrap.sh
+++ b/terraform/files/bootstrap.sh
@@ -4,8 +4,8 @@
 ## license: Apache-2.0
 
 # version
-VERSION_K9S="0.23.3"
-VERSION_CLUSTERCTL="0.3.19"
+VERSION_K9S="0.24.15"
+VERSION_CLUSTERCTL="0.3.23"
 
 ## install tools and utils at local account
 

--- a/terraform/files/deploy.sh
+++ b/terraform/files/deploy.sh
@@ -21,7 +21,7 @@ cp $HOME/clusterctl.yaml $HOME/.cluster-api/clusterctl.yaml
 
 # deploy cluster-api on mgmt cluster
 echo "deploy cluster-api with openstack provider ${CLUSTERAPI_OPENSTACK_PROVIDER_VERSION}"
-clusterctl init --infrastructure openstack:v${CLUSTERAPI_OPENSTACK_PROVIDER_VERSION} --core cluster-api:v0.3.19 -b kubeadm:v0.3.19 -c kubeadm:v0.3.19
+clusterctl init --infrastructure openstack:v${CLUSTERAPI_OPENSTACK_PROVIDER_VERSION} --core cluster-api:v0.3.23 -b kubeadm:v0.3.23 -c kubeadm:v0.3.23
 
 # wait for CAPI pods
 echo "# wait for all components are ready for cluster-api"


### PR DESCRIPTION
k9s is non-critical; the updates to k8s-capi are minimal and desirable.

Signed-off-by: Kurt Garloff <scs@garloff.de>