### PR TITLE
Upgrade to cluster-api alpha4.

### DIFF
--- a/terraform/files/bootstrap.sh
+++ b/terraform/files/bootstrap.sh
@@ -5,7 +5,7 @@
 
 # version
 VERSION_K9S="0.24.15"
-VERSION_CLUSTERCTL="0.3.23"
+VERSION_CLUSTERCTL="0.4.2"
 
 ## install tools and utils at local account
 

--- a/terraform/files/deploy.sh
+++ b/terraform/files/deploy.sh
@@ -4,7 +4,7 @@
 ## license: Apache-2.0
 
 # variables
-CLUSTERAPI_OPENSTACK_PROVIDER_VERSION=0.3.4
+CLUSTERAPI_OPENSTACK_PROVIDER_VERSION=0.4.0
 CLUSTERAPI_TEMPLATE=cluster-template.yaml
 CLUSTER_NAME=testcluster
 KUBECONFIG_WORKLOADCLUSTER=workload-cluster.yaml
@@ -21,7 +21,7 @@ cp $HOME/clusterctl.yaml $HOME/.cluster-api/clusterctl.yaml
 
 # deploy cluster-api on mgmt cluster
 echo "deploy cluster-api with openstack provider ${CLUSTERAPI_OPENSTACK_PROVIDER_VERSION}"
-clusterctl init --infrastructure openstack:v${CLUSTERAPI_OPENSTACK_PROVIDER_VERSION} --core cluster-api:v0.3.23 -b kubeadm:v0.3.23 -c kubeadm:v0.3.23
+clusterctl init --infrastructure openstack:v${CLUSTERAPI_OPENSTACK_PROVIDER_VERSION} --core cluster-api:v0.4.2 -b kubeadm:v0.4.2 -c kubeadm:v0.4.2
 
 # wait for CAPI pods
 echo "# wait for all components are ready for cluster-api"
@@ -38,7 +38,8 @@ kubectl wait --for condition=established --timeout=60s crds/openstackclusters.in
 
 # get the needed clusterapi-variables
 echo "# show used variables for clustertemplate ${CLUSTERAPI_TEMPLATE}"
-clusterctl config cluster ${CLUSTER_NAME} --list-variables --from ${CLUSTERAPI_TEMPLATE}
+#clusterctl config cluster ${CLUSTER_NAME} --list-variables --from ${CLUSTERAPI_TEMPLATE}
+clusterctl generate cluster ${CLUSTER_NAME} --list-variables --from ${CLUSTERAPI_TEMPLATE}
 
 # the need variables are set to $HOME/.cluster-api/clusterctl.yaml
 echo "# rendering clusterconfig from template"

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -1,96 +1,99 @@
 ---
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-        - 192.168.0.0/16
-    serviceDomain: cluster.local
-  controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
-    kind: KubeadmControlPlane
-    name: ${CLUSTER_NAME}-control-plane
+      cidrBlocks: ["192.168.0.0/16"] # CIDR block used by Calico.
+    serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
     kind: OpenStackCluster
     name: ${CLUSTER_NAME}
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   cloudName: ${OPENSTACK_CLOUD}
-  cloudsSecret:
+  identityRef:
     name: ${CLUSTER_NAME}-cloud-config
-    namespace: default
-  disablePortSecurity: false
-  dnsNameservers:
-    - 8.8.8.8
+    kind: Secret
   managedAPIServerLoadBalancer: true
   managedSecurityGroups: true
   nodeCidr: 10.6.0.0/24
-  useOctavia: true
+  dnsNameservers:
+  - ${OPENSTACK_DNS_NAMESERVERS}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
 metadata:
-  name: ${CLUSTER_NAME}-control-plane
-  namespace: default
+  name: "${CLUSTER_NAME}-control-plane"
+  namespace: ${NAMESPACE}
 spec:
-  infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: OpenStackMachineTemplate
-    name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: OpenStackMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+      name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
-    clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
-        extraVolumes:
-          - hostPath: /etc/kubernetes/cloud.conf
-            mountPath: /etc/kubernetes/cloud.conf
-            name: cloud
-            readOnly: true
-      controllerManager:
-        extraArgs:
-          cloud-provider: external
-        extraVolumes:
-          - hostPath: /etc/kubernetes/cloud.conf
-            mountPath: /etc/kubernetes/cloud.conf
-            name: cloud
-            readOnly: true
-          - hostPath: /etc/certs/cacert
-            mountPath: /etc/certs/cacert
-            name: cacerts
-            readOnly: true
-      imageRepository: k8s.gcr.io
-    files:
-      - content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
-        encoding: base64
-        owner: root
-        path: /etc/kubernetes/cloud.conf
-        permissions: "0600"
-      - content: ${OPENSTACK_CLOUD_CACERT_B64}
-        encoding: base64
-        owner: root
-        path: /etc/certs/cacert
-        permissions: "0600"
     initConfiguration:
       nodeRegistration:
-        kubeletExtraArgs:
-          cloud-provider: external
         name: '{{ local_hostname }}'
+        kubeletExtraArgs:
+          cloud-provider: openstack
+          cloud-config: /etc/kubernetes/cloud.conf
+    clusterConfiguration:
+      imageRepository: k8s.gcr.io
+      apiServer:
+        extraArgs:
+          cloud-provider: openstack
+          cloud-config: /etc/kubernetes/cloud.conf
+        extraVolumes:
+        - name: cloud
+          hostPath: /etc/kubernetes/cloud.conf
+          mountPath: /etc/kubernetes/cloud.conf
+          readOnly: true
+      controllerManager:
+        extraArgs:
+          cloud-provider: openstack
+          cloud-config: /etc/kubernetes/cloud.conf
+        extraVolumes:
+        - name: cloud
+          hostPath: /etc/kubernetes/cloud.conf
+          mountPath: /etc/kubernetes/cloud.conf
+          readOnly: true
+        - name: cacerts
+          hostPath: /etc/certs/cacert
+          mountPath: /etc/certs/cacert
+          readOnly: true
     joinConfiguration:
       nodeRegistration:
-        kubeletExtraArgs:
-          cloud-provider: external
         name: '{{ local_hostname }}'
+        kubeletExtraArgs:
+          cloud-config: /etc/kubernetes/cloud.conf
+          cloud-provider: openstack
+    files:
+    - path: /etc/kubernetes/cloud.conf
+      owner: root
+      permissions: "0600"
+      content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
+      encoding: base64
+    - path: /etc/certs/cacert
+      owner: root
+      permissions: "0600"
+      content: ${OPENSTACK_CLOUD_CACERT_B64}
+      encoding: base64
     postKubeadmCommands:
       - kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://docs.projectcalico.org/manifests/calico.yaml
     preKubeadmCommands:
@@ -107,96 +110,96 @@ spec:
       - echo -n "ewogICJtdHUiOiAxNDAwCn0K" | base64 -d > /etc/docker/daemon.json
       - systemctl daemon-reload
       - systemctl enable --now docker
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: "${KUBERNETES_VERSION}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
-      cloudName: ${OPENSTACK_CLOUD}
-      cloudsSecret:
-        name: ${CLUSTER_NAME}-cloud-config
-        namespace: default
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
-      sshKeyName: ${OPENSTACK_KEYPAIR_NAME}
+      sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+      cloudName: ${OPENSTACK_CLOUD}
+      identityRef:
+        name: ${CLUSTER_NAME}-cloud-config
+        kind: Secret
       securityGroups:
         - name: allow-ssh
         - name: allow-icmp
 ---
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
 metadata:
-  name: ${CLUSTER_NAME}-md-0
-  namespace: default
+  name: "${CLUSTER_NAME}-md-0"
+  namespace: ${NAMESPACE}
 spec:
-  clusterName: ${CLUSTER_NAME}
+  clusterName: "${CLUSTER_NAME}"
   replicas: ${WORKER_MACHINE_COUNT}
   selector:
-    matchLabels: null
+    matchLabels:
   template:
     spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      failureDomain: ${OPENSTACK_FAILURE_DOMAIN}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
           kind: KubeadmConfigTemplate
-          name: ${CLUSTER_NAME}-md-0
-      clusterName: ${CLUSTER_NAME}
-      failureDomain: ${OPENSTACK_FAILURE_DOMAIN}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
         kind: OpenStackMachineTemplate
-        name: ${CLUSTER_NAME}-md-0
-      version: "${KUBERNETES_VERSION}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: OpenStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
       cloudName: ${OPENSTACK_CLOUD}
-      cloudsSecret:
+      identityRef:
         name: ${CLUSTER_NAME}-cloud-config
-        namespace: default
+        kind: Secret
       flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
       image: ${OPENSTACK_IMAGE_NAME}
-      sshKeyName: ${OPENSTACK_KEYPAIR_NAME}
+      sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
       securityGroups:
         - name: allow-ssh
         - name: allow-icmp
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
       files:
-        - content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
-          encoding: base64
-          owner: root
-          path: /etc/kubernetes/cloud.conf
-          permissions: "0600"
-        - content: ${OPENSTACK_CLOUD_CACERT_B64}
-          encoding: base64
-          owner: root
-          path: /etc/certs/cacert
-          permissions: "0600"
+      - content: ${OPENSTACK_CLOUD_PROVIDER_CONF_B64}
+        encoding: base64
+        owner: root
+        path: /etc/kubernetes/cloud.conf
+        permissions: "0600"
+      - content: ${OPENSTACK_CLOUD_CACERT_B64}
+        encoding: base64
+        owner: root
+        path: /etc/certs/cacert
+        permissions: "0600"
       joinConfiguration:
         nodeRegistration:
-          kubeletExtraArgs:
-            cloud-provider: external
           name: '{{ local_hostname }}'
+          kubeletExtraArgs:
+            cloud-config: /etc/kubernetes/cloud.conf
+            cloud-provider: openstack
       preKubeadmCommands:
         - DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
         - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
@@ -213,12 +216,12 @@ spec:
         - systemctl enable --now docker
 ---
 apiVersion: v1
-data:
-  cacert: ${OPENSTACK_CLOUD_CACERT_B64}
-  clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
 kind: Secret
 metadata:
+  name: ${CLUSTER_NAME}-cloud-config
+  namespace: ${NAMESPACE}
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-  name: ${CLUSTER_NAME}-cloud-config
-  namespace: default
+data:
+  clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
+  cacert: ${OPENSTACK_CLOUD_CACERT_B64}

--- a/terraform/files/template/clusterctl.yaml.tmpl
+++ b/terraform/files/template/clusterctl.yaml.tmpl
@@ -6,6 +6,9 @@
 # Kubernetes version
 KUBERNETES_VERSION: ${kubernetes_version}
 
+# Namespace
+NAMESPACE: default
+
 # Openstack Availablity Zone
 OPENSTACK_FAILURE_DOMAIN: ${availability_zone}
 
@@ -14,8 +17,9 @@ OPENSTACK_FAILURE_DOMAIN: ${availability_zone}
 #
 OPENSTACK_EXTERNAL_NETWORK_ID: ${external}
 
-OPENSTACK_KEYPAIR_NAME: capi-keypair
+OPENSTACK_SSH_KEY_NAME: capi-keypair
 OPENSTACK_IMAGE_NAME: ubuntu-capi-image
+OPENSTACK_DNS_NAMESERVERS: 9.9.9.9
 
 OPENSTACK_CONTROL_PLANE_IP: 127.0.0.1
 OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR: ${controller_flavor}


### PR DESCRIPTION
We're using c-api 0.4.2 and openstack-c-api-provider 0.4.0 now.
Imported new templates from the latter project.
Parametrized NAMESPACE (default) and DNS_NAMESERVERS (9.9.9.9)
as well, for tweaking later if needed.

Signed-off-by: Kurt Garloff <scs@garloff.de>