### PR TITLE
Allow using std. ~/.config/openstack/clouds.yaml and secure.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ of the newly created cluster, or for creating additional clusters.
 * Terraform must be installed (https://learn.hashicorp.com/tutorials/terraform/install-cli)
 * ``terraform/clouds.yaml`` and ``terraform/secure.yaml`` files must be created
   (https://docs.openstack.org/python-openstackclient/latest/configuration/index.html#clouds-yaml)
-* place your ``clouds.yaml`` and your ``secure.yaml`` in the ``terraform`` folder. Examples are
+* place your ``clouds.yaml`` and your ``secure.yaml`` in the ``terraform`` folder (or set the
+  ``clouds_yaml_path`` to the standard "~/.config/openstack/" path where you typically store
+  the clouds access parameters and credentials. Examples are
   provided in ``clouds.yaml.sample`` and ``secure.yaml.sample``
   Note that you need ``project_domain_name`` and ``username`` in ``clouds.yaml``.
   (``username`` is normally only in ``secure.yaml`` and the ``project_domain_name`` is not

--- a/terraform/files/template/clusterctl.yaml.tmpl
+++ b/terraform/files/template/clusterctl.yaml.tmpl
@@ -17,7 +17,7 @@ OPENSTACK_FAILURE_DOMAIN: ${availability_zone}
 #
 OPENSTACK_EXTERNAL_NETWORK_ID: ${external}
 
-OPENSTACK_SSH_KEY_NAME: capi-keypair
+OPENSTACK_SSH_KEY_NAME: ${prefix}-keypair
 OPENSTACK_IMAGE_NAME: ubuntu-capi-image-${kubernetes_version}
 OPENSTACK_DNS_NAMESERVERS: 9.9.9.9
 

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -26,8 +26,8 @@ resource "openstack_networking_floatingip_associate_v2" "mgmtcluster_floatingip_
 }
 
 locals {
-  clouds = lookup(lookup(yamldecode(file("clouds.yaml")), "clouds"), var.cloud_provider)
-  secure = lookup(lookup(yamldecode(file("secure.yaml")), "clouds"), var.cloud_provider)
+  clouds = lookup(lookup(yamldecode(file("${var.clouds_yaml_path}/clouds.yaml")), "clouds"), var.cloud_provider)
+  secure = lookup(lookup(yamldecode(file("${var.clouds_yaml_path}/secure.yaml")), "clouds"), var.cloud_provider)
 }
 
 resource "openstack_compute_instance_v2" "mgmtcluster_server" {
@@ -128,7 +128,7 @@ EOF
   }
 
   provisioner "file" {
-    content     = templatefile("files/template/clusterctl.yaml.tmpl", { kubernetes_version = var.kubernetes_version, availability_zone = var.availability_zone, external = var.external, image = var.image, controller_flavor = var.controller_flavor, worker_flavor = var.worker_flavor, cloud_provider = var.cloud_provider, worker_count = var.worker_count, controller_count = var.controller_count, kind_mtu = var.kind_mtu, namespace = var.kubernetes_namespace })
+    content     = templatefile("files/template/clusterctl.yaml.tmpl", { kubernetes_version = var.kubernetes_version, availability_zone = var.availability_zone, external = var.external, image = var.image, controller_flavor = var.controller_flavor, worker_flavor = var.worker_flavor, cloud_provider = var.cloud_provider, worker_count = var.worker_count, controller_count = var.controller_count, kind_mtu = var.kind_mtu, namespace = var.kubernetes_namespace, prefix = var.prefix })
     destination = "/home/${var.ssh_username}/clusterctl.yaml"
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -83,5 +83,5 @@ variable "kubernetes_namespace" {
 variable "clouds_yaml_path" {
   description = "where to find clouds and secure.yaml"
   type        = string
-  default     = "."	# use "~/.config/openstack" for the global one
+  default     = "."
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,3 +79,9 @@ variable "kubernetes_namespace" {
   type        = string
   default     = "default"
 }
+
+variable "clouds_yaml_path" {
+  description = "where to find clouds and secure.yaml"
+  type        = string
+  default     = "."	# use "~/.config/openstack" for the global one
+}


### PR DESCRIPTION
Also prefix key names with ${prefix}.

Signed-off-by: Kurt Garloff <kurt@garloff.de>