### PR TITLE
Add in tenant-id into cloud.conf. (Issue #46)

### DIFF
--- a/terraform/files/template/cloud.conf.tmpl
+++ b/terraform/files/template/cloud.conf.tmpl
@@ -1,6 +1,7 @@
 [Global]
 auth-url=${clouds.auth.auth_url}
 tenant-name=${clouds.auth.project_name}
+tenant-id=${clouds.auth.project_id}
 domain-name=${clouds.auth.user_domain_name}
 password=${secure.auth.password}
 username=${secure.auth.username}

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -180,7 +180,7 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
-      "chmod 0600 /home/${var.ssh_username}/.ssh/id_rsa /home/${var.ssh_username}/clusterctl.yaml",
+      "chmod 0600 /home/${var.ssh_username}/.ssh/id_rsa /home/${var.ssh_username}/clusterctl.yaml /home/${var.ssh_username}/cloud.conf /home/${var.ssh_username}/clouds.yaml",
       "bash /home/${var.ssh_username}/bootstrap.sh"
     ]
   }


### PR DESCRIPTION
Also make cloud.conf and clouds.yaml 0600 (they contain credentials).
This addresses issue #46.

Signed-off-by: Kurt Garloff <kurt@garloff.de>