### PR TITLE
Pass down prefix to cleanup.sh for multi-deployment.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -54,7 +54,8 @@ clean: init
 	@rm -f .kube.config.$(ENVIRONMENT) .cluster-api.clusterctl.yaml.$(ENVIRONMENT) rendered-cluster-template.yaml.$(ENVIRONMENT)
 
 fullclean:
-	@./cleanup/cleanup.sh --verbose --full
+	prefix=$$(grep '^prefix *=' environments/environment-${ENVIRONMENT}.tfvars | sed -e 's/^[^=]*= *//' -e 's/"//g'); \
+	./cleanup/cleanup.sh --verbose --full testcluster $${prefix}
 	@rm -f ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT)
 	$(MAKE) clean
 


### PR DESCRIPTION
When you create several capi management nodes using a different prefix,
you want to selectively clean them up with fullclean. This is now
implemented -- previously capi- was hardcoded as prefix.

Signed-off-by: Kurt Garloff <kurt@garloff.de>