### PR TITLE
Don't require project_id from clouds.yaml.

### DIFF
--- a/terraform/files/template/cloud.conf.tmpl
+++ b/terraform/files/template/cloud.conf.tmpl
@@ -3,7 +3,6 @@ auth-url=${clouds.auth.auth_url}
 region="${clouds.region_name}"
 application-credential-id=${appcredid}
 application-credential-secret="${appcredsecret}"
-tenant-id=${clouds.auth.project_id}
 
 [LoadBalancer]
 manage-security-groups=true

--- a/terraform/files/template/clouds.yaml.tmpl
+++ b/terraform/files/template/clouds.yaml.tmpl
@@ -9,4 +9,3 @@ clouds:
       auth_url: ${clouds.auth.auth_url}
       application_credential_id: ${appcredid}
       application_credential_secret: "${appcredsecret}"
-      #project_id: ${clouds.auth.project_id}

--- a/terraform/files/template/clusterctl_template.sh
+++ b/terraform/files/template/clusterctl_template.sh
@@ -10,7 +10,8 @@ sudo snap install yq
 # does not consider the AuthInfo to be valid of there is no projectID. It knows how to derive it
 # from the name, but not how to derive it from an application credential. (Not sure gophercloud
 # even has the needed helpers.)
-CLOUD_YAML_ENC=$(sed 's/#project_id/project_id/' < clouds.yaml | base64 -w 0)
+PROJECTID=$(grep 'tenant.id=' cloud.conf | sed 's/^[^=]*=//')
+CLOUD_YAML_ENC=$( (cat clouds.yaml; echo "      project-id: $PROJECTID") | base64 -w 0)
 echo $CLOUD_YAML_ENC
 
 # Encode cloud.conf

--- a/terraform/files/template/upload_capi_image.sh.tmpl
+++ b/terraform/files/template/upload_capi_image.sh.tmpl
@@ -10,10 +10,16 @@ UBU_IMG_NM=ubuntu-capi-image-$KUBERNETES_VERSION
 #install Openstack CLI
 sudo apt install -y python3-openstackclient python3-octaviaclient
 # fix bug 1876317
-sudo patch -p2 -d /usr/lib/python3/dist-packages/keystoneauth1 < ~/fix-keystoneauth-plugins-unversioned.diff
+sudo patch -p2 -N -d /usr/lib/python3/dist-packages/keystoneauth1 < ~/fix-keystoneauth-plugins-unversioned.diff
 
 # convenience
 echo "export OS_CLOUD=\"$PROVIDER\"" >> $HOME/.bash_aliases
+
+# Determine project ID and inject into cloud.conf
+PROJECTID=$(openstack --os-cloud="$PROVIDER" application credential show ${prefix}-appcred -f value -c project_id)
+if ! grep '^tenant.id' cloud.conf >/dev/null; then
+  sed -i "/^application.credential.secret/atenant-id=$PROJECTID"  cloud.conf
+fi
 
 #download/upload image to openstack
 CAPIIMG=$(openstack --os-cloud $PROVIDER image list --name $UBU_IMG_NM)

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -138,7 +138,7 @@ EOF
   }
 
   provisioner "file" {
-    content     = templatefile("files/template/upload_capi_image.sh.tmpl", { kubernetes_version = var.kubernetes_version, provider = var.cloud_provider, kube_image_raw = var.kube_image_raw, image_registration_extra_flags = var.image_registration_extra_flags })
+    content     = templatefile("files/template/upload_capi_image.sh.tmpl", { kubernetes_version = var.kubernetes_version, provider = var.cloud_provider, kube_image_raw = var.kube_image_raw, image_registration_extra_flags = var.image_registration_extra_flags, prefix = var.prefix })
     destination = "/home/${var.ssh_username}/upload_capi_image.sh"
   }
 


### PR DESCRIPTION
It can be retrieved using the application credential.
So do it, and make life easier ...

Signed-off-by: Kurt Garloff <kurt@garloff.de>