### PR TITLE
Fill in SCS defaults and eliminate clouds_yaml_path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,18 @@ of the newly created cluster, or for creating additional clusters.
 ## Preparations
 
 * Terraform must be installed (https://learn.hashicorp.com/tutorials/terraform/install-cli)
-* You must have credentials to access the cloud -- either (recommended) keep them in the 
-  standard place (``~/.config/openstack/clouds.yaml`` and ``secure.yaml``) and set
-  ``clouds_yaml_path`` to ``~/.config/openstack`` OR create copies in the terraform directory.
+* You must have credentials to access the cloud. terraform will look for ``clouds.yaml``
+  and ``secure.yaml`` in the current working directory, in ``~/.config/openstack/``
+  and ``/etc/openstack`` (in this order), just like the openstack client.
   (https://docs.openstack.org/python-openstackclient/latest/configuration/index.html#clouds-yaml)
-* The terraform files create an application credential (restricted, but with all roles
-  of the configured user and without time expiration) that is passed on to the capi
-  management node.
-* As the ``v3applicationcredential`` ``auth_type`` plugin is being used, we hit a "bug"
+* You need to have ``yq`` (python3-yq or yq snap) installed.
+* As the ``v3applicationcredential`` ``auth_type`` plugin is being used, we hit a bug
   in Ubuntu 20.04 which ships python3-keystoneauth < 4.2.0, which does fail with
   unversioned ``auth_url`` endpoints.
   (See OpenStack [bug 1876317](https://bugs.launchpad.net/keystoneauth/+bug/1876317).)
-  So please ensure that you have a trailing ``/v3`` in your ``auth_url``.
-  (We do try to patch the bug away in keystoneauth1 on install, but this may not be
-   as robust as we'd like it to be.)
+  While we try to patch the bug away in the deployed instance, the patching mechanism
+  is not very robust, so we still recommend you have a versioned ``auth_url``
+  endpoint (with a trailing ``/v3``).
 * Copy the environments sample file from environments/environment-default.tfvars to
   ``environments/environment-<yourcloud>.tfvars`` and provide the necessary information like
   machine flavor or machine image.

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -21,7 +21,7 @@ ifneq (,$(wildcard ./minio.env))
   include minio.env
 endif
 
-init:
+init:	mycloud
 	@if [ ! -d .terraform/plugins ]; then terraform init; fi
 	@terraform workspace select ${ENVIRONMENT} || terraform workspace new ${ENVIRONMENT}
 
@@ -36,6 +36,9 @@ state-push: init
 
 dry-run: init
 	@terraform plan -var-file="environments/environment-$(ENVIRONMENT).tfvars" $(PARAMS)
+
+mycloud:
+	@yq --yaml-output '.clouds."$(ENVIRONMENT)"' < <(cat ./clouds.yaml ~/.config/openstack/clouds.yaml /etc/openstack/clouds.yaml 2>/dev/null) > mycloud.yaml
 
 create: init
 	@touch .deploy.$(ENVIRONMENT)
@@ -154,4 +157,4 @@ k9s: .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT) .deploy.id_rsa.$(ENVIRONMENT)
 	ssh -t -o StrictHostKeyChecking=no -i .deploy.id_rsa.$(ENVIRONMENT) $(USERNAME)@$$MGMTCLUSTER_ADDRESS \
 	"KUBECONFIG=/etc/rancher/k3s/k3s.yaml:/home/ubuntu/workload-cluster.yaml k9s --all-namespaces"
 
-PHONY: clean console attach detach ssh dry-run list deploy watch openstack create log console login k9s 
+PHONY: clean console attach detach ssh dry-run list deploy watch openstack create log console login k9s mycloud

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -38,7 +38,7 @@ dry-run: init
 	@terraform plan -var-file="environments/environment-$(ENVIRONMENT).tfvars" $(PARAMS)
 
 mycloud:
-	@yq --yaml-output '.clouds."$(ENVIRONMENT)"' < <(cat ./clouds.yaml ~/.config/openstack/clouds.yaml /etc/openstack/clouds.yaml 2>/dev/null) > mycloud.yaml
+	@yq --yaml-output '.clouds."$(ENVIRONMENT)"' < <(cat ./clouds.yaml ~/.config/openstack/clouds.yaml /etc/openstack/clouds.yaml 2>/dev/null) > mycloud.$(ENVIRONMENT).yaml
 
 create: init
 	@touch .deploy.$(ENVIRONMENT)
@@ -53,7 +53,7 @@ clean: init
 	@terraform destroy -auto-approve -var-file="environments/environment-$(ENVIRONMENT).tfvars" $(PARAMS)
 	@terraform workspace select default
 	@terraform workspace delete $(ENVIRONMENT)
-	@rm -f .deploy.$(ENVIRONMENT) .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT) .deploy.id_rsa.$(ENVIRONMENT)
+	@rm -f .deploy.$(ENVIRONMENT) .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT) .deploy.id_rsa.$(ENVIRONMENT) mycloud.$(ENVIRONMENT).yaml
 	@rm -f .kube.config.$(ENVIRONMENT) .cluster-api.clusterctl.yaml.$(ENVIRONMENT) rendered-cluster-template.yaml.$(ENVIRONMENT)
 
 fullclean:

--- a/terraform/files/deploy_cluster.sh
+++ b/terraform/files/deploy_cluster.sh
@@ -77,7 +77,9 @@ kubectl $KCONTEXT apply -f ~/openstack.yaml
 kubectl $KCONTEXT apply -f ~/cinder.yaml
 
 # Metrics server
+# kubectl $KCONTEXT create -f https://raw.githubusercontent.com/pythianarora/total-practice/master/sample-kubernetes-code/metrics-server.yaml
 # kubectl $KCONTEXT apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+# curl -L https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml | sed '/        - --kubelet-use-node-status-port/a\        - --kubelet-insecure-tls' | kubectl $KCONTEXT apply -f -
 
 echo "Wait for control plane of ${CLUSTER_NAME}"
 kubectl config use-context kind-kind
@@ -85,7 +87,7 @@ kubectl wait --timeout=20m cluster "${CLUSTER_NAME}" --for=condition=Ready
 #kubectl config use-context "${CLUSTER_NAME}-admin@${CLUSTER_NAME}"
 kubectl get openstackclusters
 # Hints
-echo "Use kubectl $KCONTEXT apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml to deploy the metrics service"
+echo "Use curl -L https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml | sed '/        - --kubelet-use-node-status-port/a\\        - --kubelet-insecure-tls' | kubectl $KCONTEXT apply -f -  to deploy the metrics service"
 echo "Use kubectl $KCONTEXT wait --for=condition=Ready --timeout=10m -n kube-system pods --all to wait for all cluster components to be ready"
 echo "Use $KCONTEXT parameter to kubectl to control the workload cluster"
 # eof

--- a/terraform/files/deploy_cluster.sh
+++ b/terraform/files/deploy_cluster.sh
@@ -77,11 +77,15 @@ kubectl $KCONTEXT apply -f ~/openstack.yaml
 kubectl $KCONTEXT apply -f ~/cinder.yaml
 
 # Metrics server
-# kubectl $KCONTEXT create -f https://raw.githubusercontent.com/pythianarora/total-practice/master/sample-kubernetes-code/metrics-server.yaml
+# kubectl $KCONTEXT apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 
 echo "Wait for control plane of ${CLUSTER_NAME}"
 kubectl config use-context kind-kind
 kubectl wait --timeout=20m cluster "${CLUSTER_NAME}" --for=condition=Ready
 #kubectl config use-context "${CLUSTER_NAME}-admin@${CLUSTER_NAME}"
+kubectl get openstackclusters
+# Hints
+echo "Use kubectl $KCONTEXT apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml to deploy the metrics service"
+echo "Use kubectl $KCONTEXT wait --for=condition=Ready --timeout=10m -n kube-system pods --all to wait for all cluster components to be ready"
 echo "Use $KCONTEXT parameter to kubectl to control the workload cluster"
 # eof

--- a/terraform/files/fix-keystoneauth-plugins-unversioned.diff
+++ b/terraform/files/fix-keystoneauth-plugins-unversioned.diff
@@ -1,3 +1,25 @@
+This is a minimal version of
+
+commit ad46262148e7b099e6c7239887e20ade5b8e6ac8
+Author: Lance Bragstad <lbragstad@gmail.com>
+Date:   Fri May 1 01:02:12 2020 +0000
+
+    Inject /v3 in token path for v3 plugins
+    
+    Without this, it's possible to get HTTP 404 errors from keystone if
+    OS_AUTH_URL isn't versioned (e.g., https://keystone.example.com/ instead
+    of https://keystone.example.com/v3), even if OS_IDENTITY_API is set to
+    3.
+    
+    This commit works around this issue by checking the AUTH_URL before
+    building the token_url and appending '/v3' to the URL before sending the
+    request.
+    
+    Closes-Bug: 1876317
+    
+    Change-Id: Ic75f0c9b36022b884105b87bfe05f4f8292d53b2
+
+
 diff --git a/keystoneauth1/identity/v3/base.py b/keystoneauth1/identity/v3/base.py
 index 20a86db..bcd6441 100644
 --- a/keystoneauth1/identity/v3/base.py

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -32,7 +32,7 @@ resource "openstack_networking_floatingip_associate_v2" "mgmtcluster_floatingip_
 }
 
 locals {
-  clouds = lookup(lookup(yamldecode(file("${var.clouds_yaml_path}/clouds.yaml")), "clouds"), var.cloud_provider)
+  clouds = yamldecode(file("mycloud.yaml"))
 }
 
 resource "openstack_compute_instance_v2" "mgmtcluster_server" {

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -32,7 +32,7 @@ resource "openstack_networking_floatingip_associate_v2" "mgmtcluster_floatingip_
 }
 
 locals {
-  clouds = yamldecode(file("mycloud.yaml"))
+  clouds = yamldecode(file("mycloud.${var.cloud_provider}.yaml"))
 }
 
 resource "openstack_compute_instance_v2" "mgmtcluster_server" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,21 +12,25 @@ variable "prefix" {
 variable "image" {
   description = "openstack glance image for nova instances"
   type        = string
+  default     = "Ubuntu 20.04"
 }
 
 variable "kind_flavor" {
   description = "openstack nova flavor for instance running kind (capi mgmt node)"
   type        = string
+  default     = "SCS-1V:4:10"
 }
 
 variable "controller_flavor" {
   description = "openstack nova flavor for instances running the k8s management nodes"
   type        = string
+  default     = "SCS-2V:4:20"
 }
 
 variable "worker_flavor" {
   description = "openstack nova flavor for instances running the k8s worker nodes"
   type        = string
+  default     = "SCS-2V:4:20"
 }
 
 variable "availability_zone" {
@@ -42,6 +46,7 @@ variable "external" {
 variable "ssh_username" {
   description = "ssh username for instances"
   type        = string
+  default     = "ubuntu"
 }
 
 variable "kubernetes_version" {
@@ -86,8 +91,3 @@ variable "kubernetes_namespace" {
   default     = "default"
 }
 
-variable "clouds_yaml_path" {
-  description = "where to find clouds and secure.yaml"
-  type        = string
-  default     = "."
-}


### PR DESCRIPTION
For getting the cloud settings, we just clouds.yaml from
., ~/.config/openstack/ and /etc/openstack, just like terraform
and openstack client do.