### PR TITLE
Drop the uneeded systemd unit file for docker0 MTU.

### DIFF
--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -58,21 +58,6 @@ write_files:
     owner: root:root
     path: /tmp/daemon.json
     permissions: '0644'
-  - content: |
-      [Unit]
-      Description=Docker Set MTU to ${var.kind_mtu}
-      After=docker.service
-      Requires=docker.socket
-      
-      [Service]
-      Type=oneshot
-      ExecStart=/bin/ip link set dev docker0 mtu ${var.kind_mtu}
-      
-      [Install]
-      WantedBy=multi-user.target
-    owner: root:root
-    path: /etc/systemd/system/docker-mtu.service
-    permissions: '0644'
 runcmd:
   - echo nf_conntrack > /etc/modules-load.d/90-nf_conntrack.conf
   - modprobe nf_conntrack

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -68,7 +68,6 @@ runcmd:
   - groupadd docker
   - usermod -aG docker ${var.ssh_username}
   - apt -y install docker.io yamllint qemu-utils
-  - systemctl enable --now docker-mtu
 EOF
 
   connection {


### PR DESCRIPTION
The config file /etc/docker/daemon.json is still fully effective
and all that's needed. So stop setting the MTU in the docker0 device,
as it just adds uneeded complexity/cruft and may be fragile as
Jonas rightly pointed out in PR #23.

Signed-off-by: Kurt Garloff <kurt@garloff.de>