### PR TITLE
Fix grep to avoid counting Failed texts.

### DIFF
--- a/terraform/files/sonobuoy.sh
+++ b/terraform/files/sonobuoy.sh
@@ -35,6 +35,6 @@ echo "$REPORT"
 declare -i fail=0
 while read number; do
 	let fail+=$number
-done < <(echo "$REPORT" | grep Failed | sed 's/Failed: //')
+done < <(echo "$REPORT" | grep 'Failed: ' | sed 's/Failed: //')
 if test $fail != 0; then exit $((4+$fail)); fi
 echo "=== Sonobuoy conformance tests passed ==="


### PR DESCRIPTION
We sum up the number of error, thus only grep for 'Failed: '.

Signed-off-by: Kurt Garloff <kurt@garloff.de>