### PR TITLE
Pass E2E_PROVIDER=openstack to enable some tests.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -124,9 +124,17 @@ check: .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT) .deploy.id_rsa.$(ENVIRONMENT)
 	ssh -o StrictHostKeyChecking=no -i .deploy.id_rsa.$(ENVIRONMENT) $(USERNAME)@$$MGMTCLUSTER_ADDRESS "bash sonobuoy.sh $(SONOMODE)"
 
 # Pass SONOMODE="--mode light" for a quick check
-quickcheck:
+check-quick:
 	$(MAKE) check SONOMODE="--mode quick"
 
+check-conformance:
+	$(MAKE) check SONOMODE="--mode certified-conformance"
+
+check-storage:
+	$(MAKE) check SONOMODE="--e2e-focus='Storage' --e2e-skip='Disruptive'"
+
+check-csi:
+	$(MAKE) check SONOMODE="--e2e-focus='CSI' --e2e-skip='Disruptive'"
 
 watch: .deploy.id_rsa.$(ENVIRONMENT) .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT)
 	@source ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); \

--- a/terraform/files/sonobuoy.sh
+++ b/terraform/files/sonobuoy.sh
@@ -15,10 +15,13 @@ if ! test -x ./sonobuoy; then
 	chmod +x ./sonobuoy || exit 2
 	rm ${SONOTARBALL}
 fi
-echo "=== Running sonobuoy conformance tests ... $@ ==="
 export KUBECONFIG=testcluster.yaml
 if ! test -r "$KUBECONFIG"; then echo "No $KUBECONFIG" 1>&2; exit 3; fi
-./sonobuoy run "$@" || exit 4
+#./sonobuoy status 2>/dev/null
+#./sonobuoy delete --wait
+START=$(date +%s)
+echo "=== Running sonobuoy conformance tests ... $@ ==="
+./sonobuoy run --plugin-env=e2e.E2E_PROVIDER=openstack "$@" || exit 4
 if test "$1" == "--mode" -a "$2" == "quick"; then SLP=10; ALL=""; else SLP=60; ALL="--all"; fi
 while true; do
 	sleep $SLP
@@ -26,15 +29,22 @@ while true; do
 	date +%FT%TZ
 	echo "$COMPLETE"
 	if echo "$COMPLETE" | grep "has completed" >/dev/null 2>&1; then break; fi
+	#./sonobuoy logs
 done
 echo "=== Collecting results ==="
 resfile=$(./sonobuoy retrieve)
+./sonobuoy delete $ALL
 REPORT=$(./sonobuoy results $resfile)
 echo "$REPORT"
-./sonobuoy delete $ALL
+END=$(date +%s)
 declare -i fail=0
 while read number; do
 	let fail+=$number
 done < <(echo "$REPORT" | grep Failed | sed 's/Failed: //')
-if test $fail != 0; then exit $((4+$fail)); fi
-echo "=== Sonobuoy conformance tests passed ==="
+./sonobuoy delete $ALL --wait
+if test $fail != 0; then
+	echo "FAIL: Investigate $resfile for further inspection" 1>&2
+	exit $((4+$fail))
+fi
+rm $resfile
+echo "=== Sonobuoy conformance tests passed in $((END-START))s ==="


### PR DESCRIPTION
Rename quickcheck to check-quick.
Also add additional targets:
check-conformance: Full conformance tests (also disruptive ones)
check-storage: Quick storage test suite
check-csi: Full storage test suite

Sidenote: We seem to be using a csi mock driver for most (or all?)
tests, so we may have no real testing for our cinder-CSI yet.

Signed-off-by: Kurt Garloff <kurt@garloff.de>