### PR TITLE
Delete pods and pvcs when deleting cluster.

### DIFF
--- a/terraform/files/delete_cluster.sh
+++ b/terraform/files/delete_cluster.sh
@@ -7,6 +7,18 @@ export KUBECONFIG=~/.kube/config
 if test -n "$1"; then CLUSTER_NAME="$1"; else CLUSTER_NAME=testcluster; fi
 kubectl config use-context kind-kind
 echo "Deleting cluster $CLUSTER_NAME"
+KCONTEXT="--context=${CLUSTER_NAME}-admin@${CLUSTER_NAME}"
+PODS=$(kubectl $KCONTEXT get pods | grep -v '^NAME' | awk '{ print $1; }')
+for pod in $PODS; do
+	echo -en " Delete pod $pod\n "
+	kubectl $KCONTEXT delete pod $pod
+done
+PVCS=$(kubectl $KCONTEXT get persistentvolumeclaims | grep -v '^NAME' | awk '{ print $1; }')
+for pvc in $PVCS; do
+	echo -en " Delete pvc $pvc\n "
+	kubectl $KCONTEXT delete persistentvolumeclaim $pvc
+done
+sleep 1
 kubectl delete cluster "$CLUSTER_NAME"
 kubectl config delete-context "$CLUSTER_NAME-admin@$CLUSTER_NAME"
 kubectl config delete-user "$CLUSTER_NAME-admin"


### PR DESCRIPTION
We want to avoid leaving OpenStack resources behind.
Thus we want to clean up persistent volume claims.
To be able to do so, these must not be in-use, which we achieve
by also deleting all pods.

To be done: We probably would need to treat loadbalancers like
persistent volume claims. (Will do after we have good test cases
for these.)

Signed-off-by: Kurt Garloff <kurt@garloff.de>