### PR TITLE
Deploy metrics pod first.

### DIFF
--- a/terraform/files/create_cluster.sh
+++ b/terraform/files/create_cluster.sh
@@ -68,20 +68,21 @@ do
     let SLEEP+=10
 done
 
-# OpenStack, Cinder
-bash ./apply_openstack_integration.sh "$CLUSTER_NAME" || exit $?
-bash ./apply_cindercsi.sh "$CLUSTER_NAME" || exit $?
-
-# NGINX ingress, Metrics
-DEPLOY_NGINX_INGRESS=$(yq eval '.DEPLOY_NGINX_INGRESS' $CCCFG)
-if test "$DEPLOY_NGINX_INGRESS" = "true"; then
-  bash ./apply_nginx_ingress.sh "$CLUSTER_NAME" || exit $?
-fi
+# Metrics
 DEPLOY_METRICS=$(yq eval '.DEPLOY_METRICS' $CCCFG)
 if test "$DEPLOY_METRICS" = "true"; then
   bash ./apply_metrics.sh "$CLUSTER_NAME" || exit $?
 fi
 
+# OpenStack, Cinder
+bash ./apply_openstack_integration.sh "$CLUSTER_NAME" || exit $?
+bash ./apply_cindercsi.sh "$CLUSTER_NAME" || exit $?
+
+# NGINX ingress
+DEPLOY_NGINX_INGRESS=$(yq eval '.DEPLOY_NGINX_INGRESS' $CCCFG)
+if test "$DEPLOY_NGINX_INGRESS" = "true"; then
+  bash ./apply_nginx_ingress.sh "$CLUSTER_NAME" || exit $?
+fi
 echo "Wait for control plane of ${CLUSTER_NAME}"
 kubectl config use-context kind-kind
 kubectl wait --timeout=20m cluster "${CLUSTER_NAME}" --for=condition=Ready || exit 10


### PR DESCRIPTION
We might decide to hook up cinder and openstack pods to the metrics
service, so reorder. (This is not strictly necessary.)

Signed-off-by: Kurt Garloff <kurt@garloff.de>