### PR TITLE
Bump default k8s version to v1.21.6.

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,7 +52,7 @@ variable "ssh_username" {
 variable "kubernetes_version" {
   description = "desired kubernetes version for the workload cluster"
   type        = string
-  default     = "v1.21.5"
+  default     = "v1.21.6"
 }
 
 variable "kube_image_raw" {


### PR DESCRIPTION
Signed-off-by: Kurt Garloff <kurt@garloff.de>