### PR TITLE
Use new URL for kube images. (#89)

### DIFF
--- a/terraform/files/template/upload_capi_image.sh.tmpl
+++ b/terraform/files/template/upload_capi_image.sh.tmpl
@@ -23,9 +23,11 @@ fi
 
 #download/upload image to openstack
 CAPIIMG=$(openstack --os-cloud $PROVIDER image list --name $UBU_IMG_NM)
+IMGURL=https://minio.services.osism.tech/openstack-k8s-capi-images
+IMAGESRC=$IMGURL/ubuntu-2004-kube-$VERSION_CAPI_IMAGE/$UBU_IMG.qcow2
 if test -z "$CAPIIMG"; then
   # TODO: Check signature
-  wget https://images.osism.tech/openstack-k8s-capi-images/ubuntu-2004-kube-$VERSION_CAPI_IMAGE/$UBU_IMG.qcow2
+  wget $IMAGESRC
   FMT=qcow2
   IMGINFO=$(qemu-img info $UBU_IMG.qcow2)
   DIKKSZ=$(echo "$IMGINFO" | grep '^virtual size' | sed 's/^[^(]*(\([0-9]*\) bytes).*$/\1/')
@@ -36,7 +38,7 @@ if test -z "$CAPIIMG"; then
     qemu-img convert $UBU_IMG.qcow2 -O raw -S 4k $UBU_IMG.raw && rm $UBU_IMG.qcow2 || exit 1
   fi
   #TODO min-disk, min-ram, other std. image metadata
-  openstack --os-cloud $PROVIDER image create --disk-format $FMT --min-ram 1024 --min-disk $DISKSZ --property image_build_date="$IMGDATE" --property image_original_user=ubuntu --property architecture=x86_64 --property hypervisor_type=kvm --property os_distro=ubuntu --property os_version="20.04" --property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_rng_model=virtio --property image_source=https://images.osism.tech/openstack-k8s-capi-images/ubuntu-2004-kube-$VERSION_CAPI_IMAGE/$UBU_IMG.qcow2 --property kubernetes_version=$KUBERNETES_VERSION --tag managed_by_osism $IMGREG_EXTRA --file $UBU_IMG.$FMT $UBU_IMG_NM &
+  openstack --os-cloud $PROVIDER image create --disk-format $FMT --min-ram 1024 --min-disk $DISKSZ --property image_build_date="$IMGDATE" --property image_original_user=ubuntu --property architecture=x86_64 --property hypervisor_type=kvm --property os_distro=ubuntu --property os_version="20.04" --property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_rng_model=virtio --property image_source=$IMAGESRC --property kubernetes_version=$KUBERNETES_VERSION --tag managed_by_osism $IMGREG_EXTRA --file $UBU_IMG.$FMT $UBU_IMG_NM &
   sleep 5
   echo "Waiting for image $UBU_IMG_NM: "
   let -i ctr=0


### PR DESCRIPTION
images.osism.tech -> minio.services.osism.tech

Signed-off-by: Kurt Garloff <kurt@garloff.de>