### PR TITLE
Fix/nginx clustername

### DIFF
--- a/terraform/files/apply_nginx_ingress.sh
+++ b/terraform/files/apply_nginx_ingress.sh
@@ -9,6 +9,6 @@ echo "Deploy NGINX ingress controller to $CLUSTER_NAME"
 if test ! -r nginx-ingress-controller.yaml; then
 	curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.1/deploy/static/provider/cloud/deploy.yaml > nginx-ingress-controller.yaml
 fi
-sed "s/ingress-nginx-controller/ingress-nginx-controller-${CLUSTER_NAME}/" nginx-ingress-controller.yaml > nginx-ingress-controller-${CLUSTER_NAME}.yaml
-kubectl $KCONTEXT apply -f nginx-ingress-controller-${CLUSTERNAME}.yaml
+sed "s/\(ingress-nginx-controller\)/\1-${CLUSTER_NAME}/" nginx-ingress-controller.yaml > nginx-ingress-controller-${CLUSTER_NAME}.yaml
+kubectl $KCONTEXT apply -f nginx-ingress-controller-${CLUSTER_NAME}.yaml
 

--- a/terraform/files/apply_nginx_ingress.sh
+++ b/terraform/files/apply_nginx_ingress.sh
@@ -9,5 +9,6 @@ echo "Deploy NGINX ingress controller to $CLUSTER_NAME"
 if test ! -r nginx-ingress-controller.yaml; then
 	curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.1/deploy/static/provider/cloud/deploy.yaml > nginx-ingress-controller.yaml
 fi
-kubectl $KCONTEXT apply -f nginx-ingress-controller.yaml
+sed "s/ingress-nginx-controller/ingress-nginx-controller-${CLUSTER_NAME}/" nginx-ingress-controller.yaml > nginx-ingress-controller-${CLUSTER_NAME}.yaml
+kubectl $KCONTEXT apply -f nginx-ingress-controller-${CLUSTERNAME}.yaml
 

--- a/terraform/files/delete_cluster.sh
+++ b/terraform/files/delete_cluster.sh
@@ -21,7 +21,7 @@ done
 INPODS=$(kubectl $KCONTEXT --namespace ingress-nginx get pods) 
 if echo "$INPODS" | grep nginx >/dev/null 2>&1; then
 	echo -en " Delete ingress \n "
-	kubectl $KCONTEXT delete -f nginx-ingress-controller.yaml
+	kubectl $KCONTEXT delete -f nginx-ingress-controller-${CLUSTER_NAME}.yaml
 fi
 # Delete persisten volumes
 PVCS=$(kubectl $KCONTEXTNS get persistentvolumeclaims | grep -v '^NAME' | awk '{ print $1; }')


### PR DESCRIPTION
This works around the missing namespace isolation from openstack cluster api provider that leads to name clashes when creating loadbalancers for ingress controllers.