### PR TITLE
Update calico to v3.21.2.

### DIFF
--- a/terraform/files/bootstrap.sh
+++ b/terraform/files/bootstrap.sh
@@ -4,8 +4,8 @@
 ## license: Apache-2.0
 
 # version
-VERSION_K9S="0.25.7"
-VERSION_CLUSTERCTL="1.0.1"
+VERSION_K9S="0.25.8"
+VERSION_CLUSTERCTL="1.0.2"
 
 # Start image registration early
 bash upload_capi_image.sh

--- a/terraform/files/deploy_cluster_api.sh
+++ b/terraform/files/deploy_cluster_api.sh
@@ -23,7 +23,7 @@ clusterctl init --infrastructure openstack:v${CLUSTERAPI_OPENSTACK_PROVIDER_VERS
 
 # Install calicoctl
 # TODO: Check signature
-curl -o calicoctl -O -L  "https://github.com/projectcalico/calicoctl/releases/download/v3.20.0/calicoctl" 
+curl -o calicoctl -O -L  "https://github.com/projectcalico/calicoctl/releases/download/v3.21.2/calicoctl" 
 chmod +x calicoctl
 sudo mv calicoctl /usr/local/bin
 


### PR DESCRIPTION
Also bump clusterctl (1.0.1 -> 1.0.2) and k9s (0.25.7 -> 0.25.8).

Signed-off-by: Kurt Garloff <kurt@garloff.de>