### PR TITLE
Fix/comment occm cinder version

### DIFF
--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -18,5 +18,5 @@ kind_mtu             = <number>         # defaults to 1400
 node_cidr            = "CIDR"           # defaults to "10.8.0.0/20"
 deploy_nginx_ingress = "<boolean>"      # defaults to "true"
 deploy_metrics_service   = "<boolean>"  # defaults to "true"
-deploy_k8s_openstack_git = "<boolean>"  # defaults to "false"
-deploy_k8s_cindercsi_git = "<boolean>"  # defaults to "false"
+deploy_k8s_openstack_git = "<boolean>"  # defaults to "false", enable for k8s >= 1.22, dont for < 1.20
+deploy_k8s_cindercsi_git = "<boolean>"  # defaults to "false", dito

--- a/terraform/files/apply_cindercsi.sh
+++ b/terraform/files/apply_cindercsi.sh
@@ -27,9 +27,17 @@ if test "$DEPLOY_K8S_CINDERCSI_GIT" = "true"; then
   done
   # Note: We leave out the secret which we should already have
   cat cinder-csi-*-rbac.yaml cinder-csi-*plugin.yaml csi-cinder-driver.yaml cinder-provider.yaml > cindercsi-git.yaml
-  kubectl $KCONTEXT apply -f cindercsi-git.yaml || exit 8
+  CCSI=cindercsi-git.yaml
 else
   kubectl $KCONTEXT apply -f ~/external-snapshot-crds.yaml || exit 8
-  kubectl $KCONTEXT apply -f ~/cinder.yaml || exit 8
+  CCSI=cinder.yaml
 fi
+cat >cindercsi-${CLUSTER_NAME}.sed <<EOT
+/ *\- name: CLUSTER_NAME/{
+n
+s/value: .*\$/value: ${CLUSTER_NAME}/
+}
+EOT
+sed -f cindercsi-${CLUSTER_NAME}.sed $CCSI > cindercsi-${CLUSTER_NAME}.yaml
+kubectl $KCONTEXT apply -f cindercsi-${CLUSTER_NAME}.yaml || exit 8
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -110,13 +110,13 @@ variable "deploy_nginx_ingress" {
 }
 
 variable "deploy_k8s_openstack_git" {
-  description = "deploy k8s openstack provider from github instead of local copy"
+  description = "deploy k8s openstack provider from github instead of local copy, set to true for k8s >= 1.22, dont set it for < 1.20"
   type        = bool
   default     = false
 }
 
 variable "deploy_k8s_cindercsi_git" {
-  description = "deploy k8s cinder CSI provider from github instead of local copy"
+  description = "deploy k8s cinder CSI provider from github instead of local copy, dito"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Use the latest for k8s >= 1.22, don't do it for <1.20.