### PR TITLE
Detect yq version and support yq 4 snap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dashboard or GUI that would shield less experienced users from all the YAML.
   and ``secure.yaml`` in the current working directory, in ``~/.config/openstack/``
   and ``/etc/openstack`` (in this order), just like the openstack client.
   (<https://docs.openstack.org/python-openstackclient/latest/configuration/index.html#clouds-yaml>)
-* You need to have ``yq`` (python3-yq) installed.
+* You need to have ``yq`` (python3-yq or yq snap) installed.
 * As the ``v3applicationcredential`` ``auth_type`` plugin is being used, we hit a bug
   in Ubuntu 20.04 which ships python3-keystoneauth < 4.2.0, which does fail with
   unversioned ``auth_url`` endpoints.

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -24,6 +24,16 @@ ifneq (,$(wildcard ./minio.env))
   include minio.env
 endif
 
+YQVERSION=$(shell yq --version | sed -e 's/^yq //' -e 's/^.*version //')
+YQMAJOR=$(shell YQV="$(YQVERSION)"; echo "$${YQV%%.*}")
+ifeq ($(YQMAJOR),2)
+  YQ=yq --yaml-output
+  YQIN=
+else
+  YQ=yq eval
+  YQIN=-
+endif
+
 init:	mycloud
 	@if [ ! -d .terraform/plugins ]; then terraform init; fi
 	@terraform workspace select ${ENVIRONMENT} || terraform workspace new ${ENVIRONMENT}
@@ -41,7 +51,7 @@ dry-run: init
 	@terraform plan -var-file="environments/environment-$(ENVIRONMENT).tfvars" $(PARAMS)
 
 mycloud:
-	@yq --yaml-output '.clouds."$(ENVIRONMENT)"' < <(cat ./clouds.yaml ~/.config/openstack/clouds.yaml /etc/openstack/clouds.yaml 2>/dev/null) > mycloud.$(ENVIRONMENT).yaml
+	@$(YQ) '.clouds."$(ENVIRONMENT)"' $(YQIN) < <(cat ./clouds.yaml ~/.config/openstack/clouds.yaml /etc/openstack/clouds.yaml 2>/dev/null) > mycloud.$(ENVIRONMENT).yaml
 
 create: init
 	@touch .deploy.$(ENVIRONMENT)


### PR DESCRIPTION
So no need to fiddle with pip on Ubuntu, where the yq 4.x snap is
readily available, but not so the yq 2.x that we have in SUSE
python3-yq. Detect and support both.

Signed-off-by: Kurt Garloff <kurt@garloff.de>