### PR TITLE
Remove duplicate settings from clusterctl.yaml.

### DIFF
--- a/terraform/files/template/clusterctl.yaml.tmpl
+++ b/terraform/files/template/clusterctl.yaml.tmpl
@@ -15,7 +15,7 @@ KUBERNETES_VERSION: ${kubernetes_version}
 OPENSTACK_IMAGE_NAME: ubuntu-capi-image-${kubernetes_version}
 
 # deploy openstack and cindercsi from github instead of local copies
-# note: use git for k8s > 1.21, do not use git for < 1.20
+# hint: use git for k8s > 1.21, do not use git for < 1.20
 DEPLOY_K8S_OPENSTACK_GIT: ${deploy_k8s_openstack_git}
 DEPLOY_K8S_CINDERCSI_GIT: ${deploy_k8s_cindercsi_git}
 
@@ -37,7 +37,7 @@ OPENSTACK_FAILURE_DOMAIN: ${availability_zone}
 # Nodes CIDR
 NODE_CIDR: ${node_cidr}
 
-# Set MTU for k8s CNI network (50 smaller than cloud)
+# Set MTU for k8s CNI network (50 smaller than cloud, 0 = auto)
 MTU_VALUE: 0
 
 # Openstack external Network ID
@@ -49,15 +49,6 @@ OPENSTACK_DNS_NAMESERVERS: ${dns_nameserver}
 OPENSTACK_SSH_KEY_NAME: ${prefix}-keypair
 
 OPENSTACK_CONTROL_PLANE_IP: 127.0.0.1
-
-# deploy nginx ingress controller
-DEPLOY_NGINX_INGRESS: ${deploy_nginx_ingress}
-# deploy metrics service
-DEPLOY_METRICS: ${deploy_metrics_service}
-
-# deploy openstack and cindercsi from github instead of local copies
-DEPLOY_K8S_OPENSTACK_GIT: ${deploy_k8s_openstack_git}
-DEPLOY_K8S_CINDERCSI_GIT: ${deploy_k8s_cindercsi_git}
 
 # Use anti-affinity server groups (not working yet)
 OPENSTACK_ANTIAFFINITY: ${anti_affinity}


### PR DESCRIPTION
Commit 8e2288bc was supposed to rearrange the settings for which
services to deploy from git (instead of old copies).
It erroneously duplicated them, which can be confusing to users.
This fixes it.

Signed-off-by: Kurt Garloff <kurt@garloff.de>