### PR TITLE
Use cluster specific name for LB cleanup.

### DIFF
--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -109,15 +109,15 @@ fi
 echo "Deleting cluster $CLUSTER"
 # cleanup loadbalancers
 if test -n "$NOCASCADE"; then
-POOLS=$(resourcelist "loadbalancer pool" "\(clusterapi\|kube_service_kubernetes_ingress-nginx_ingress-nginx-controller\)")
+POOLS=$(resourcelist "loadbalancer pool" "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)")
 for POOL in $POOLS; do
 	#MEMBERS=$(resourcelist "loadbalancer member" clusterapi $POOL)
-	cleanup "loadbalancer member" "\(clusterapi\|kube_service_kubernetes_ingress-nginx_ingress-nginx-controller\)" $POOL
+	cleanup "loadbalancer member" "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)" $POOL
 done
 cleanup_list "loadbalancer pool" "" "" "$POOLS"
-cleanup "loadbalancer listener" "\(clusterapi\|kube_service_kubernetes_ingress-nginx_ingress-nginx-controller\)"
+cleanup "loadbalancer listener" "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)"
 fi
-LBS=$(resourcelist loadbalancer "\(clusterapi\|kube_service_kubernetes_ingress-nginx_ingress-nginx-controller\)" "" vip_address)
+LBS=$(resourcelist loadbalancer "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)" "" vip_address)
 #cleanup_list "floating ip" 2 "" "$LBS"
 while read LB FIP; do
 	if test -z "$FIP"; then continue; fi


### PR DESCRIPTION
With PR #93, we include the cluster name in the loadbalancer created
from the nginx ingress controller. This avoids naming conflicts.
The cleanup.sh script (called by make fullclean) had not reflected
this change and thus missed to cleanup the loadbalancer.

Signed-off-by: Kurt Garloff <kurt@garloff.de>