### PR TITLE
Update to latest k8s-1.21.9.

### DIFF
--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -10,7 +10,7 @@ clusterapi_version   = "<1.x.y>"		    # defaults to "1.0.4"
 capi_openstack_version = "<0.x.y>"		  # defaults to "0.5.0"
 image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
 # Settings for testcluster
-kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.21.6"
+kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.21.9"
 kube_image_raw       = "<boolean>"      # defaults to "false"
 calico_version       = "<v3.xx.y>"		  # defaults to "v3.22.0"
 controller_flavor    = "<flavor>"       # defaults to SCS-2V:4:20s (ditto)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,7 +70,7 @@ variable "capi_openstack_version" {
 variable "kubernetes_version" {
   description = "desired kubernetes version for the workload cluster"
   type        = string
-  default     = "v1.21.6"
+  default     = "v1.21.9"
 }
 
 variable "kube_image_raw" {


### PR DESCRIPTION
We also support 1.22.6/1.23.1, but let's keep to the latest 1.21.x
for now.

Signed-off-by: Kurt Garloff <kurt@garloff.de>