### PR TITLE
Default k8s version is 1.21.10 now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `node_cidr` | `NODE_CIDR` | SCS | `10.8.0.0/20` | IPv4 address range (CIDR notation) for workload nodes
 `use_cilium` | `USE_CILIUM` | SCS | `false` | Use cilium as CNI instead of calico
 `calico_version` | | SCS | `v3.22.0` | Version of the Calico CNI provider (ignored if `use_cilium` is set)
-`kubernetes_version` | `KUBERNETES_VERSION` | capo | `v1.21.9` | Kubernetes version deployed into workload cluster
+`kubernetes_version` | `KUBERNETES_VERSION` | capo | `v1.21.10` | Kubernetes version deployed into workload cluster
 ` ` | `OPENSTACK_IMAGE_NAME` | capo | `ubuntu-capi-image-${KUBERNETES_VERION}` | Image name for k8s controller and worker nodes
 `kube_image_raw` | `OPENSTACK_IMAGE_RAW` | SCS | `false` | Register images in raw format (instead of qcow2), good for ceph COW
 `image_registration_extra_flags` | `OPENSTACK_IMAGE_REGISTATION_EXTRA_FLAGS` | SCS | `""` | Extra flags passed during image registration

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -4,13 +4,14 @@ prefix               = "<prefix_for_openstack_resources>"  # defaults to "capi"
 cloud_provider       = "<name_for_provider>"
 availability_zone    = "<az>"
 external             = "<external_network_name>"
+dns_nameserver       = "<DNS_IP>"	# defaults to 9.9.9.9
 kind_flavor          = "<flavor>"       # defaults to SCS-1V:4:20  (larger does not hurt)
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"
 clusterapi_version   = "<1.x.y>"		    # defaults to "1.0.4"
 capi_openstack_version = "<0.x.y>"		  # defaults to "0.5.2"
 image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
 # Settings for testcluster
-kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.21.9"
+kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.21.10"
 kube_image_raw       = "<boolean>"      # defaults to "false"
 calico_version       = "<v3.xx.y>"		  # defaults to "v3.22.0"
 controller_flavor    = "<flavor>"       # defaults to SCS-2V:4:20s (consider -2D with dedicated CPUs for multicontroller setups)

--- a/terraform/files/bin/create_cluster.sh
+++ b/terraform/files/bin/create_cluster.sh
@@ -11,7 +11,7 @@ if test -n "$1"; then CLUSTER_NAME="$1"; fi
 KUBECONFIG_WORKLOADCLUSTER="${CLUSTER_NAME}.yaml"
 
 # Ensure image is there
-wait_capi_image.sh "$1"
+wait_capi_image.sh "$1" || exit 1
 
 # Switch to capi mgmt cluster
 export KUBECONFIG=~/.kube/config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,7 +70,7 @@ variable "capi_openstack_version" {
 variable "kubernetes_version" {
   description = "desired kubernetes version for the workload cluster"
   type        = string
-  default     = "v1.21.9"
+  default     = "v1.21.10"
 }
 
 variable "kube_image_raw" {


### PR DESCRIPTION
Signed-off-by: Kurt Garloff <kurt@garloff.de>