### PR TITLE
Update kind to v0.12.0

### DIFF
--- a/terraform/files/bin/install_kind.sh
+++ b/terraform/files/bin/install_kind.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-KIND_VERSION=0.11.1
+KIND_VERSION=0.12.0
 sudo wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
 sudo chmod +x /usr/local/bin/kind
 kind create cluster


### PR DESCRIPTION
This comes with a k8s-v1.23.4 k8s image. Other changes:
- haproxy for multi control-plane clusters is distroless
- Base image updates (containerd 1.5.10, crictl 1.23.0, cni plugins 1.1.0,
  containerd/fuse-overlayfs-snapshotter 1.0.4)

Signed-off-by: Kurt Garloff <kurt@garloff.de>