### PR TITLE
Change cluster-api to version 1.0.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `kind_flavor` | | SCS | `SCS-1V:4:20` | Flavor to be used for the k8s capi mgmt node
 `image` | | SCS | `Ubuntu 20.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
-`clusterapi_version` | | SCS | `1.0.4` | Version of the cluster-API incl. `clusterctl`
+`clusterapi_version` | | SCS | `1.0.5` | Version of the cluster-API incl. `clusterctl`
 `capi_openstack_version` | | SCS | `0.5.2` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
 
 Parameters controlling both management node creation and cluster creation:

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -7,7 +7,7 @@ external             = "<external_network_name>"
 dns_nameservers      = [ "DNS_IP1", "DNS_IP2" ]	  # defaults to [ "5.1.66.255", "185.150.99.255" ] (FF MUC)
 kind_flavor          = "<flavor>"                 # defaults to SCS-1V:4:20  (larger does not hurt)
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"
-clusterapi_version   = "<1.x.y>"		  # defaults to "1.0.4"
+clusterapi_version   = "<1.x.y>"		  # defaults to "1.0.5"
 capi_openstack_version = "<0.x.y>"		  # defaults to "0.5.2"
 image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
 # Settings for testcluster

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,7 @@ variable "calico_version" {
 variable "clusterapi_version" {
   description = "desired version of cluster-api"
   type        = string
-  default     = "1.0.4"
+  default     = "1.0.5"
 }
 
 variable "capi_openstack_version" {


### PR DESCRIPTION
https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.0.5
* Retry for listObjByGVK and for delete during clusterctl upgrade
* Fix panic in Cluster webhook
* Using latest version in E2E tests

Signed-off-by: Kurt Garloff <kurt@garloff.de>