### PR TITLE
Update calico to v3.22.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 ---|---|---|---|---
 `node_cidr` | `NODE_CIDR` | SCS | `10.8.0.0/20` | IPv4 address range (CIDR notation) for workload nodes
 `use_cilium` | `USE_CILIUM` | SCS | `false` | Use cilium as CNI instead of calico
-`calico_version` | | SCS | `v3.22.0` | Version of the Calico CNI provider (ignored if `use_cilium` is set)
+`calico_version` | | SCS | `v3.22.1` | Version of the Calico CNI provider (ignored if `use_cilium` is set)
 `kubernetes_version` | `KUBERNETES_VERSION` | capo | `v1.21.10` | Kubernetes version deployed into workload cluster
 ` ` | `OPENSTACK_IMAGE_NAME` | capo | `ubuntu-capi-image-${KUBERNETES_VERION}` | Image name for k8s controller and worker nodes
 `kube_image_raw` | `OPENSTACK_IMAGE_RAW` | SCS | `true` | Register images in raw format (instead of qcow2), good for ceph COW

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -13,7 +13,7 @@ image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
 # Settings for testcluster
 kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.21.10"
 kube_image_raw       = "<boolean>"      # defaults to "true"
-calico_version       = "<v3.xx.y>"	# defaults to "v3.22.0"
+calico_version       = "<v3.xx.y>"	# defaults to "v3.22.1"
 controller_flavor    = "<flavor>"       # defaults to SCS-2D:4:20s (use etcd tweaks if you only have SCS-2V:4:20 in multi-controller setups)
 worker_flavor        = "<flavor>"       # defaults to SCS-2V:4:20  (larger helps)
 controller_count     = <number>         # defaults to 1 (0 skips testcluster creation)

--- a/terraform/files/kubernetes-manifests.d/calico.yaml
+++ b/terraform/files/kubernetes-manifests.d/calico.yaml
@@ -16,7 +16,7 @@ data:
   # Configure the MTU to use for workload interfaces and tunnels.
   # By default, MTU is auto-detected, and explicitly setting this field should not be required.
   # You can override auto-detection by providing a non-zero value.
-  veth_mtu: "1392"
+  veth_mtu: "0"
 
   # The CNI network configuration to install on each node. The special
   # values in this config will be automatically populated.
@@ -4084,7 +4084,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.22.0
+          image: docker.io/calico/cni:v3.22.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -4111,7 +4111,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.22.0
+          image: docker.io/calico/cni:v3.22.1
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4152,7 +4152,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.22.0
+          image: docker.io/calico/pod2daemon-flexvol:v3.22.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -4163,7 +4163,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.22.0
+          image: docker.io/calico/node:v3.22.1
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4382,7 +4382,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.22.0
+          image: docker.io/calico/kube-controllers:v3.22.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,7 +52,7 @@ variable "ssh_username" {
 variable "calico_version" {
   description = "desired version of calico"
   type        = string
-  default     = "v3.22.0"
+  default     = "v3.22.1"
 }
 
 variable "clusterapi_version" {


### PR DESCRIPTION
* Bug fixes with Typha operator setups with >100 nodes.
* Fix with wireguard host encryption startup deadlock.
* ipset 7.11 (for IPVS compatibility).
* Update container build components.

Signed-off-by: Kurt Garloff <kurt@garloff.de>