### PR TITLE
Fix terraform warning.

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,10 +8,10 @@ output "private_key" {
   sensitive = true
 }
 
-resource "local_file" "id_rsa" {
-  filename          = ".deploy.id_rsa.${var.cloud_provider}"
-  file_permission   = "0600"
-  sensitive_content = openstack_compute_keypair_v2.keypair.private_key
+resource "local_sensitive_file" "id_rsa" {
+  filename        = ".deploy.id_rsa.${var.cloud_provider}"
+  file_permission = "0600"
+  content         = openstack_compute_keypair_v2.keypair.private_key
 }
 
 resource "local_file" "MGMTCLUSTER_ADDRESS" {


### PR DESCRIPTION
local_file with sensitive_content is local_sensitive_file with content
now.

Signed-off-by: Kurt Garloff <kurt@garloff.de>