### PR TITLE
Add create-monitor=true to could.conf to solve LB issues.

### DIFF
--- a/terraform/files/template/cloud.conf.tmpl
+++ b/terraform/files/template/cloud.conf.tmpl
@@ -7,3 +7,4 @@ application-credential-secret="${appcredsecret}"
 [LoadBalancer]
 manage-security-groups=true
 use-octavia=true
+create-monitor=true


### PR DESCRIPTION
See issue #173: When the LB tries to talk to all 3 nodes in round robin
mode, it always typically fails twice before finding the one member
where the nginx L7 LB accepts the connections.
Having a (TCP) health monitor makes the LB aware of which members
respond and which ones do not.

This can be achieved by the global setting create-monitor=true
in OCCM's cloud.conf configuration file.
The only question is: Why does it default to false currently?

Signed-off-by: Kurt Garloff <kurt@garloff.de>