### PR TITLE
Use kustomize to enable monitor (and proxy).

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ environment | clusterctl.yaml | provenance | default | script |  meaning
 ---|---|---|---|---|---
 `deploy_metrics` | `DEPLOY_METRICS` | SCS | `true` | `apply_metrics.sh` | Deploy metrics service to nodes to make `kubectl top` work
 `deploy_nginx_ingress` | `DEPLOY_NGINX_INGRESS` | SCS | `true` | `apply_nginx_ingress.sh` | Deploy NGINX ingress controller (this spawns an OpenStack Loadbalancer), pass version (e.g. `v1.1.2`) to explicitly choose the version
+` ` | `NGINX_INGRESS_PROXY` | SCS | `true` | (ditto) | Configure LB and nginx to get real IP via PROXY protocol
 `deploy_cert_manager` | `DEPLOY_CERT_MANAGER` | SCS | `false` | `apply_cert_manager.sh` | Deploy cert-manager, pass version (e.g. `v1.7.1`) to explicitly choose a version
 `deploy_flux` | `DEPLOY_FLUX` | SCS | `false` | | Deploy flux2 into the cluster
 

--- a/Release-Notes-R2.md
+++ b/Release-Notes-R2.md
@@ -33,14 +33,25 @@ R2 was released on 2022-03-23.
 ### per-cluster app cred
 
 
-## Bugfixes
+## Important Bugfixes
 
 ### dns
 
 ### loadbalancer name conflict
 
-### nginx health-monitor and proxy support
+### nginx-ingress health-monitor and proxy support
 
+The upstream nginx-ingress controller deployment files uses an `externalTrafficPolicy: Local`
+setting, which avoids unnecessary hops and also avoids forwarded requests that appear to
+originate from the internal cluster. It however requires the L3 loadbalancer to use a
+health-monitor. This was not explicitly set in the past, so we could end up 10 seconds on
+the initial connection attempt (to a 3-node cluster). This has been addressed by
+kustomization of the nginx-ingress deployment.
+[#175](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/pull/175).
+
+Using the kustomization, the option `NGINX_INGRESS_PROXY` setting has been introduced,
+allowing the http/https services to receive the real IP address via the PROXY protocol.
+It is enabled by default.
 
 ## Upgrade/Migration notes
 

--- a/Release-Notes-R2.md
+++ b/Release-Notes-R2.md
@@ -3,6 +3,8 @@
 k8s-cluster-api-provider was provided with R1 of Sovereign
 Cloud Stack and has since seen major updates.
 
+R2 was released on 2022-03-23.
+
 ## Updated software
 
 ### capi v1.0.x and openstack capi provider 0.5.x
@@ -37,6 +39,7 @@ Cloud Stack and has since seen major updates.
 
 ### loadbalancer name conflict
 
+### nginx health-monitor and proxy support
 
 
 ## Upgrade/Migration notes
@@ -51,7 +54,9 @@ Cloud Stack and has since seen major updates.
 
 ### Incomplete change capabilties (no removal of services)
 
-### Loadbalancer latency
+### 4 CNCF fails with cilium
+
+### Updatability
 
 ## Future roadmap
 

--- a/terraform/files/bin/apply_cert_manager.sh
+++ b/terraform/files/bin/apply_cert_manager.sh
@@ -17,7 +17,7 @@ fi
 # kubectl $KCONTEXT apply -f https://github.com/cert-manager/cert-manager/releases/download/v${CERTMGR_VERSION}/cert-manager.yaml
 if test ! -s ~/kubernetes-manifests.d/cert-manager-${CERTMGR_VERSION}.yaml; then
 	# FIXME: Check sig
-	curl -L https://github.com/cert-manager/cert-manager/releases/download/${CERTMGR_VERSION}/cert-manager.yaml > ~/kubernetes-manifests.d/cert-manager-${CERTMGR_VERSION}.yaml
+	curl -L https://github.com/cert-manager/cert-manager/releases/download/${CERTMGR_VERSION}/cert-manager.yaml > ~/kubernetes-manifests.d/cert-manager-${CERTMGR_VERSION}.yaml || exit 2
 fi
 kubectl $KCONTEXT apply -f ~/kubernetes-manifests.d/cert-manager-${CERTMGR_VERSION}.yaml || exit 9
 # TODO: Optionally test, using cert-manager-test.yaml
@@ -29,7 +29,7 @@ kubectl $KCONTEXT apply -f ~/kubernetes-manifests.d/cert-manager-${CERTMGR_VERSI
 #	tar xzf kubectl-cert-manager.tar.gz && rm kubectl-cert-manager.tar.gz
 #	sudo mv kubectl-cert_manager /usr/local/bin
 #fi
-# cmctl
+# cmctl -- don't treat trouble as fatal error
 if ! test -x /usr/local/bin/cmctl-$CERTMGR_VERSION; then
 	OS=linux; ARCH=$(uname -m | sed 's/x86_64/amd64/')
 	# FIXME: Check sig

--- a/terraform/files/bin/apply_nginx_ingress.sh
+++ b/terraform/files/bin/apply_nginx_ingress.sh
@@ -22,6 +22,7 @@ if test ! -s base/nginx-ingress-controller-${NGINX_VERSION}.yaml; then
 fi
 ln -sf nginx-ingress-controller-${NGINX_VERSION}.yaml base/nginx-ingress-controller.yaml
 sed -i "s@set-real-ip-from: .*\$@set-real-ip-from: \"${NODE_CIDR}\"@" nginx-proxy/nginx-proxy-cfgmap.yaml
+sed -i "s@proxy-real-ip-cidr: .*\$@proxy-real-ip-cidr: \"${NODE_CIDR}\"@" nginx-proxy/nginx-proxy-cfgmap.yaml
 if test "$NGINX_INGRESS_PROXY" = "$false"; then
 	kustomize build nginx-monitor > nginx-ingress-${CLUSTER_NAME}.yaml || exit 3
 else

--- a/terraform/files/bin/apply_nginx_ingress.sh
+++ b/terraform/files/bin/apply_nginx_ingress.sh
@@ -18,14 +18,14 @@ NODE_CIDR=$(yq eval '.NODE_CIDR' $CCCFG)
 cd ~/kubernetes-manifests.d/nginx-ingress
 echo "Deploy NGINX ingress $NGINX_VERSION controller to $CLUSTER_NAME"
 if test ! -s base/nginx-ingress-controller-${NGINX_VERSION}.yaml; then
-	curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml > base/nginx-ingress-controller-${NGINX_VERSION}.yaml
+	curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml > base/nginx-ingress-controller-${NGINX_VERSION}.yaml || exit 2
 fi
 ln -sf nginx-ingress-controller-${NGINX_VERSION}.yaml base/nginx-ingress-controller.yaml
 sed -i "s@set-real-ip-from: .*\$@set-real-ip-from: \"${NODE_CIDR}\"@" nginx-proxy/nginx-proxy-cfgmap.yaml
 if test "$NGINX_INGRESS_PROXY" = "$false"; then
-	kustomize build nginx-monitor > nginx-ingress-${CLUSTER_NAME}.yaml
+	kustomize build nginx-monitor > nginx-ingress-${CLUSTER_NAME}.yaml || exit 3
 else
-	kustomize build nginx-proxy > nginx-ingress-${CLUSTER_NAME}.yaml
+	kustomize build nginx-proxy > nginx-ingress-${CLUSTER_NAME}.yaml || exit 3
 fi
 kubectl $KCONTEXT apply -f nginx-ingress-${CLUSTER_NAME}.yaml
 

--- a/terraform/files/bin/apply_nginx_ingress.sh
+++ b/terraform/files/bin/apply_nginx_ingress.sh
@@ -12,10 +12,20 @@ elif test "$DEPLOY_NGINX_INGRESS" = "false"; then
 else
 	NGINX_VERSION="$DEPLOY_NGINX_INGRESS"
 fi
+NGINX_INGRESS_PROXY=$(yq eval '.NGINX_INGRESS_PROXY' $CCCFG)
+NODE_CIDR=$(yq eval '.NODE_CIDR' $CCCFG)
 
+cd ~/kubernetes-manifests.d/nginx-ingress
 echo "Deploy NGINX ingress $NGINX_VERSION controller to $CLUSTER_NAME"
-if test ! -s ~/kubernetes-manifests.d/nginx-ingress-controller-${NGINX_VERSION}.yaml; then
-	curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml > ~/kubernetes-manifests.d/nginx-ingress-controller-${NGINX_VERSION}.yaml
+if test ! -s base/nginx-ingress-controller-${NGINX_VERSION}.yaml; then
+	curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml > base/nginx-ingress-controller-${NGINX_VERSION}.yaml
 fi
-kubectl $KCONTEXT apply -f ~/kubernetes-manifests.d/nginx-ingress-controller-${NGINX_VERSION}.yaml
+ln -sf nginx-ingress-controller-${NGINX_VERSION}.yaml base/nginx-ingress-controller.yaml
+sed -i "s@set-real-ip-from: .*\$@set-real-ip-from: \"${NODE_CIDR}\"@" nginx-proxy/nginx-proxy-cfgmap.yaml
+if test "$NGINX_INGRESS_PROXY" = "$false"; then
+	kustomize build nginx-monitor > nginx-ingress-${CLUSTER_NAME}.yaml
+else
+	kustomize build nginx-proxy > nginx-ingress-${CLUSTER_NAME}.yaml
+fi
+kubectl $KCONTEXT apply -f nginx-ingress-${CLUSTER_NAME}.yaml
 

--- a/terraform/files/bin/bootstrap.sh
+++ b/terraform/files/bin/bootstrap.sh
@@ -19,7 +19,7 @@ upload_capi_image.sh
 # install kubectl
 sudo snap install kubectl --classic
 sudo apt install -y binutils
-#sudo snap install kustomize
+sudo snap install kustomize
 
 # setup aliases and environment
 echo "# setup environment"

--- a/terraform/files/bin/delete_cluster.sh
+++ b/terraform/files/bin/delete_cluster.sh
@@ -18,10 +18,8 @@ done
 # Delete nginx ingress
 INPODS=$(kubectl $KCONTEXT --namespace ingress-nginx get pods) 
 if echo "$INPODS" | grep nginx >/dev/null 2>&1; then
-	NGINX_VERSION=$(yq eval '.DEPLOY_NGINX_INGERSS' $CCCFG)
-	if test "$NGINX_VERSION" = "true"; then NGINX_VERSION="v1.1.2"; fi
 	echo -en " Delete ingress \n "
-	kubectl $KCONTEXT delete -f ~/kubernetes-manifests.d/nginx-ingress-controller${NGINX_VERSION}.yaml
+	kubectl $KCONTEXT delete -f ~/kubernetes-manifests.d/nginx-ingress/nginx-ingress-${CLUSTER_NAME}.yaml
 fi
 # Delete persisten volumes
 PVCS=$(kubectl $KCONTEXT get persistentvolumeclaims | grep -v '^NAME' | awk '{ print $1; }')

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/base/kustomization.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nginx-ingress-controller.yaml

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/base/nginx-ingress-controller-v1.1.2.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/base/nginx-ingress-controller-v1.1.2.yaml
@@ -1,0 +1,682 @@
+#GENERATED FOR K8S 1.20
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  name: ingress-nginx
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - ingress-controller-leader
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx-admission
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx-admission
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - appProtocol: http
+    name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  - appProtocol: https
+    name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-controller-admission
+  namespace: ingress-nginx
+spec:
+  ports:
+  - appProtocol: https
+    name: https-webhook
+    port: 443
+    targetPort: webhook
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  minReadySeconds: 0
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
+        - --election-id=ingress-controller-leader
+        - --controller-class=k8s.io/ingress-nginx
+        - --ingress-class=nginx
+        - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+        - --validating-webhook=:8443
+        - --validating-webhook-certificate=/usr/local/certificates/cert
+        - --validating-webhook-key=/usr/local/certificates/key
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LD_PRELOAD
+          value: /usr/local/lib/libmimalloc.so
+        image: k8s.gcr.io/ingress-nginx/controller:v1.1.2@sha256:28b11ce69e57843de44e3db6413e98d09de0f6688e33d4bd384002a44f78405c
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /wait-shutdown
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 443
+          name: https
+          protocol: TCP
+        - containerPort: 8443
+          name: webhook
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 90Mi
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /usr/local/certificates/
+          name: webhook-cert
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ingress-nginx
+      terminationGracePeriodSeconds: 300
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: ingress-nginx-admission
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission-create
+  namespace: ingress-nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.2
+        helm.sh/chart: ingress-nginx-4.0.18
+      name: ingress-nginx-admission-create
+    spec:
+      containers:
+      - args:
+        - create
+        - --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.$(POD_NAMESPACE).svc
+        - --namespace=$(POD_NAMESPACE)
+        - --secret-name=ingress-nginx-admission
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
+        imagePullPolicy: IfNotPresent
+        name: create
+        securityContext:
+          allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+      serviceAccountName: ingress-nginx-admission
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission-patch
+  namespace: ingress-nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.2
+        helm.sh/chart: ingress-nginx-4.0.18
+      name: ingress-nginx-admission-patch
+    spec:
+      containers:
+      - args:
+        - patch
+        - --webhook-name=ingress-nginx-admission
+        - --namespace=$(POD_NAMESPACE)
+        - --patch-mutating=false
+        - --secret-name=ingress-nginx-admission
+        - --patch-failure-policy=Fail
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
+        imagePullPolicy: IfNotPresent
+        name: patch
+        securityContext:
+          allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+      serviceAccountName: ingress-nginx-admission
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.1.2
+    helm.sh/chart: ingress-nginx-4.0.18
+  name: ingress-nginx-admission
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ingress-nginx-controller-admission
+      namespace: ingress-nginx
+      path: /networking/v1/ingresses
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validate.nginx.ingress.kubernetes.io
+  rules:
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+  sideEffects: None

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-monitor/kustomization.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-monitor/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../base
+patches:
+  - nginx-monitor.yaml

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-monitor/nginx-monitor.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-monitor/nginx-monitor.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+  annotations:
+    loadbalancer.openstack.org/enable-health-monitor: "true"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-monitor/nginx-monitor.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-monitor/nginx-monitor.yaml
@@ -9,4 +9,3 @@ metadata:
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-nomonitor/kustomization.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-nomonitor/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../base
+patches:
+  - nginx-nomonitor.yaml

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-nomonitor/nginx-nomonitor.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-nomonitor/nginx-nomonitor.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+  annotations:
+    loadbalancer.openstack.org/enable-health-monitor: "false"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/kustomization.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../base
+patches:
+  - nginx-monitor.yaml
+  - nginx-proxy-cfgmap.yaml
+  - nginx-proxy-lb.yaml

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-monitor.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-monitor.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+  annotations:
+    loadbalancer.openstack.org/enable-health-monitor: "true"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-monitor.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-monitor.yaml
@@ -9,4 +9,3 @@ metadata:
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
-

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
@@ -9,4 +9,3 @@ data:
   real-ip-header: "proxy_protcol"
   # FIXME: Could set exact address here
   set-real-ip-from: "0.0.0.0/0"
-

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
@@ -5,11 +5,8 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
-  #proxy-protocol: "True"
-  #real-ip-header: "proxy_protcol"
-  # FIXME: Could set exact address here, but keeping internal provides protection already
-  #set-real-ip-from: "0.0.0.0/0"
   # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap
   use-proxy-protocol: "true"
+  # FIXME: Could set exact LB VIP address here, NODE_CIDR is a good start
   proxy-real-ip-cidr: "0.0.0.0/0"
   #enable-real-ip: "true"

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  proxy-protocol: "True"
+  real-ip-header: "proxy_protcol"
+  # FIXME: Could set exact address here
+  set-real-ip-from: "0.0.0.0/0"
+

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-cfgmap.yaml
@@ -5,7 +5,11 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
-  proxy-protocol: "True"
-  real-ip-header: "proxy_protcol"
-  # FIXME: Could set exact address here
-  set-real-ip-from: "0.0.0.0/0"
+  #proxy-protocol: "True"
+  #real-ip-header: "proxy_protcol"
+  # FIXME: Could set exact address here, but keeping internal provides protection already
+  #set-real-ip-from: "0.0.0.0/0"
+  # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap
+  use-proxy-protocol: "true"
+  proxy-real-ip-cidr: "0.0.0.0/0"
+  #enable-real-ip: "true"

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-lb.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-lb.yaml
@@ -6,4 +6,3 @@ metadata:
   namespace: ingress-nginx
   annotations:
     loadbalancer.openstack.org/proxy-protocol: "true"
-

--- a/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-lb.yaml
+++ b/terraform/files/kubernetes-manifests.d/nginx-ingress/nginx-proxy/nginx-proxy-lb.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+  annotations:
+    loadbalancer.openstack.org/proxy-protocol: "true"
+

--- a/terraform/files/template/clusterctl.yaml.tmpl
+++ b/terraform/files/template/clusterctl.yaml.tmpl
@@ -22,6 +22,8 @@ DEPLOY_K8S_CINDERCSI_GIT: ${deploy_k8s_cindercsi_git}
 USE_CILIUM: ${use_cilium}
 # deploy nginx ingress controller
 DEPLOY_NGINX_INGRESS: ${deploy_nginx_ingress}
+# Use PROXY protocol to get real IPs
+NGINX_INGRESS_PROXY: true
 # deploy cert-manager
 DEPLOY_CERT_MANAGER: ${deploy_cert_manager}
 # deploy flux2


### PR DESCRIPTION
This is a different approach to fixing #173:
We can explicitly ask the OCCM to use a health monitor, see discussion
in #174. This is preferable, as we can leave the LB defaults as is.

Use kustomize to actually do the changes to the downloaded nginx
deployment file, as this is a rather robust way.

Being at it, also allow enabling the proxy protocol, so out backends
see the real IP (in the http header set by our nginx) and not just the
VIP from the LB.

We save the generated nginx deployment file, so we can use it for
cleanup in delete_cluster.sh again.

Also: Ship the nginx-i-c-v1.1.2 deployment file directly.

Signed-off-by: Kurt Garloff <kurt@garloff.de>