### PR TITLE
Make mgmt node appcred unrestricted.

### DIFF
--- a/Release-Notes-R2.md
+++ b/Release-Notes-R2.md
@@ -34,6 +34,10 @@ R2 was released on 2022-03-23.
 
 ### per-cluster app cred
 
+We use an unrestricted application credential on the management node now,
+so we can create per-cluster application credentials on it for better
+isolation. Note that pre-cluster application credentials have not yet
+been implemented.
 
 ## Important Bugfixes
 

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -5,9 +5,9 @@ resource "openstack_compute_keypair_v2" "keypair" {
 
 # - application credential -
 resource "openstack_identity_application_credential_v3" "appcred" {
-  name        = "${var.prefix}-appcred"
-  description = "Credential for the ${var.prefix} management"
-  #unrestricted = true
+  name         = "${var.prefix}-appcred"
+  description  = "Credential for the ${var.prefix} management"
+  unrestricted = true
 }
 
 # - management cluster -


### PR DESCRIPTION
This will allow subordinate appcreds per cluster (#109),
which are however not yet implemented.
As this affects the mgmt node creation, we want to have it
done already, as the incremental changes then can be done
without recreation of the mgmt node.

Signed-off-by: Kurt Garloff <kurt@garloff.de>