### PR TITLE
Disable the usage of proxy protocol by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ environment | clusterctl.yaml | provenance | default | script |  meaning
 ---|---|---|---|---|---
 `deploy_metrics` | `DEPLOY_METRICS` | SCS | `true` | `apply_metrics.sh` | Deploy metrics service to nodes to make `kubectl top` work
 `deploy_nginx_ingress` | `DEPLOY_NGINX_INGRESS` | SCS | `true` | `apply_nginx_ingress.sh` | Deploy NGINX ingress controller (this spawns an OpenStack Loadbalancer), pass version (e.g. `v1.1.2`) to explicitly choose the version
-` ` | `NGINX_INGRESS_PROXY` | SCS | `true` | (ditto) | Configure LB and nginx to get real IP via PROXY protocol
+` ` | `NGINX_INGRESS_PROXY` | SCS | `false` | (ditto) | Configure LB and nginx to get real IP via PROXY protocol; may cause trouble for pod to LB connections.
 `deploy_cert_manager` | `DEPLOY_CERT_MANAGER` | SCS | `false` | `apply_cert_manager.sh` | Deploy cert-manager, pass version (e.g. `v1.7.1`) to explicitly choose a version
 `deploy_flux` | `DEPLOY_FLUX` | SCS | `false` | | Deploy flux2 into the cluster
 

--- a/Release-Notes-R2.md
+++ b/Release-Notes-R2.md
@@ -126,7 +126,8 @@ kustomization of the nginx-ingress deployment.
 
 Using the kustomization, the option `NGINX_INGRESS_PROXY` setting has also been introduced,
 allowing the http/https services to receive the real IP address via the PROXY protocol.
-It is enabled by default, as we expect most users to find this desirable.
+It is disabled by default; while we expect most users to find this desirable, it can create
+challenges for internal access to the nginx ingress.
 
 ## Upgrade/Migration notes
 

--- a/terraform/files/template/clusterctl.yaml.tmpl
+++ b/terraform/files/template/clusterctl.yaml.tmpl
@@ -23,7 +23,7 @@ USE_CILIUM: ${use_cilium}
 # deploy nginx ingress controller
 DEPLOY_NGINX_INGRESS: ${deploy_nginx_ingress}
 # Use PROXY protocol to get real IPs
-NGINX_INGRESS_PROXY: true
+NGINX_INGRESS_PROXY: false
 # deploy cert-manager
 DEPLOY_CERT_MANAGER: ${deploy_cert_manager}
 # deploy flux2


### PR DESCRIPTION
If nginx expects inbound connections to use it, this works fine when the
connections come from the LB that has been configured to use the proxy
protocol. However, talking to ingress directly from the pods does then
no longer work (as noone injects the proxy proto then).

This means we should probably not enable it by default.

This should address #184.

Signed-off-by: Kurt Garloff <kurt@garloff.de>