### PR TITLE
Bump capo to version 0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `image` | | SCS | `Ubuntu 20.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
 `clusterapi_version` | | SCS | `1.0.5` | Version of the cluster-API incl. `clusterctl`
-`capi_openstack_version` | | SCS | `0.5.2` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
+`capi_openstack_version` | | SCS | `0.5.3` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
 
 Parameters controlling both management node creation and cluster creation:
 

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -8,7 +8,7 @@ dns_nameservers      = [ "DNS_IP1", "DNS_IP2" ]	  # defaults to [ "5.1.66.255", 
 kind_flavor          = "<flavor>"                 # defaults to SCS-1V:4:20  (larger does not hurt)
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"
 clusterapi_version   = "<1.x.y>"		  # defaults to "1.0.5"
-capi_openstack_version = "<0.x.y>"		  # defaults to "0.5.2"
+capi_openstack_version = "<0.x.y>"		  # defaults to "0.5.3"
 image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
 # Settings for testcluster
 kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.21.10"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "clusterapi_version" {
 variable "capi_openstack_version" {
   description = "desired version of the OpenStack cluster-api provider"
   type        = string
-  default     = "0.5.2"
+  default     = "0.5.3"
 }
 
 variable "kubernetes_version" {


### PR DESCRIPTION
Most notably, this probably fixes our issue #179 (floating ip allocation
in a loop if something goes wrong with the loadbalancer).
The rest are minor cleanups and bugfixes.

Signed-off-by: Kurt Garloff <kurt@garloff.de>