### PR TITLE
Latest OCCM templates use --cluster-name=${CLUSTER_NAME}.

### DIFF
--- a/Release-Notes-R2.md
+++ b/Release-Notes-R2.md
@@ -108,7 +108,7 @@ separated list and default to the excellent name service provided by
 We had experienced UDP:53 failures with quad9 
 (which was the old default) before.
 
-### loadbalancer name conflict (#93)
+### loadbalancer name conflict (#93, #191)
 
 The loadbalancer would previoiusly be created without encoding the name of cluster in
 its name -- this would lead to conflicts and thus result in the inability to manage

--- a/terraform/files/bin/apply_openstack_integration.sh
+++ b/terraform/files/bin/apply_openstack_integration.sh
@@ -21,7 +21,12 @@ if test "$DEPLOY_K8S_OPENSTACK_GIT" = "true"; then
 else
   OCCM=openstack.yaml
 fi
-sed -e "/^            \- \/bin\/openstack\-cloud\-controller\-manager/a\            - --cluster-name=${CLUSTER_NAME}" \
-    -e "/^        \- \/bin\/openstack\-cloud\-controller\-manager/a\        - --cluster-name=${CLUSTER_NAME}" $OCCM > ~/${CLUSTER_NAME}/deployed-manifests.d/openstack-ccm.yaml
+if grep '\-\-cluster\-name=' $OCCM >/dev/null 2>&1; then
+	sed "/ *\- name: CLUSTER_NAME/n
+s/value: kubernetes/value: ${CLUSTER_NAME}/" $OCCM > ~/${CLUSTER_NAME}/deployed-manifests.d/openstack-ccm.yaml
+else
+	sed -e "/^            \- \/bin\/openstack\-cloud\-controller\-manager/a\            - --cluster-name=${CLUSTER_NAME}" \
+	    -e "/^        \- \/bin\/openstack\-cloud\-controller\-manager/a\        - --cluster-name=${CLUSTER_NAME}" $OCCM > ~/${CLUSTER_NAME}/deployed-manifests.d/openstack-ccm.yaml
+fi
 kubectl $KCONTEXT apply -f ~/${CLUSTER_NAME}/deployed-manifests.d/openstack-ccm.yaml || exit 7
 


### PR DESCRIPTION
So our patch to actually set the cluster name is no longer
required. Unfortuantely, the OCCM template sets kubernetes
as cluster-name, so the whole upstream improvement is useless.

We now are back to the issue that we have conflicting loadbalancer
names.

We need to use a different patch to set the CLUSTER_NAME ...
Detect new template and to this!

Signed-off-by: Kurt Garloff <kurt@garloff.de>