### PR TITLE
Consider master/main as version 99.99.99.

### DIFF
--- a/terraform/files/bin/openstack-kube-versions.inc
+++ b/terraform/files/bin/openstack-kube-versions.inc
@@ -12,6 +12,11 @@ min_snapshot_master="v1.21.0"
 # Convert vxx.yy.zz to the number xxyyzz. Also works for z.y.z (0x0y0z).
 dotversion()
 {
+	if test "$1" = "latest" -o "$1" = "main" -o "$1" = "master" -o "$1" = "HEAD"; then
+		VERSION=999999
+		echo $VERSION
+		return
+	fi
 	VERS=${1#v}
 	one=${VERS%%.*}
 	two=${VERS#*.}


### PR DESCRIPTION
Thus newer than any versioned thing, helping to make
version comparisons do what they should.

Signed-off-by: Kurt Garloff <kurt@garloff.de>