### PR TITLE
Support case where cloud_provider unequals ENVIRONMENT.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -34,6 +34,8 @@ else
   YQIN=-
 endif
 
+CLOUD=$(shell ( grep '^cloud_provider' environments/environment-$(ENVIRONMENT).tfvars || echo $(ENVIRONMENT) ) | sed 's@^cloud_provider[^=]*= *"*\([^"]*\).*$$@\1@' )
+
 GITBRANCH=$(shell git branch | grep '^*' | sed 's/^* //')
 
 init:	mycloud
@@ -52,8 +54,8 @@ state-push: init
 dry-run: init
 	terraform plan -var-file="environments/environment-$(ENVIRONMENT).tfvars" -var "git_branch=$(GITBRANCH)" $(PARAMS)
 
-mycloud:
-	@$(YQ) '.clouds."$(ENVIRONMENT)"' $(YQIN) < <(cat ./clouds.yaml ~/.config/openstack/clouds.yaml /etc/openstack/clouds.yaml 2>/dev/null) > mycloud.$(ENVIRONMENT).yaml
+mycloud: environments/environment-$(ENVIRONMENT).tfvars
+	@$(YQ) '.clouds."$(CLOUD)"' $(YQIN) < <(cat ./clouds.yaml ~/.config/openstack/clouds.yaml /etc/openstack/clouds.yaml 2>/dev/null) > mycloud.$(CLOUD).yaml
 
 gitchk:
 	@git diff -r origin/$(GITBRANCH) > git.diff


### PR DESCRIPTION
The generation of mycloud.$(ENVIRONMENT).yaml assumed that the cloud has
the same name as ENVIRONMENT. This is not always true; users are free
to chose cloud_provider="SomeOtherName" in
environments/environment-${ENVIRONMENT}.tfvars.

We now correctly extract cloud_provider from it and extract the
${cloud_provider} info from clouds.yaml and put it into
mycloud.${cloud_provider}.yaml where terraform looks for it.

Should be included in 3.x and 3.0.x.

Signed-off-by: Kurt Garloff <kurt@garloff.de>