### PR TITLE
Fix/img reg nohup

### DIFF
--- a/terraform/files/bin/get_k8s_git.sh
+++ b/terraform/files/bin/get_k8s_git.sh
@@ -4,6 +4,7 @@
 # (c) Kurt Garloff <garloff@osb-alliance.com>, 3/2022
 # SPDX-License-Identifier: CC-BY-SA-4.9
 cd
+getent hosts github.com || sleep 30
 git clone https://github.com/SovereignCloudStack/k8s-cluster-api-provider || exit 1
 cd k8s-cluster-api-provider
 if test -n "$1"; then git checkout "$1" || exit 1; fi

--- a/terraform/files/bin/upload_capi_image.sh
+++ b/terraform/files/bin/upload_capi_image.sh
@@ -30,7 +30,8 @@ if test -z "$CAPIIMG"; then
   fi
   #TODO min-disk, min-ram, other std. image metadata
   echo "Creating image $UBU_IMG_NM from $UBU_IMG.$FMT"
-  openstack image create --disk-format $FMT --min-ram 1024 --min-disk $DISKSZ --property image_build_date="$IMGDATE" --property image_original_user=ubuntu --property architecture=x86_64 --property hypervisor_type=kvm --property os_distro=ubuntu --property os_version="20.04" --property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_rng_model=virtio --property image_source=$IMAGESRC --property kubernetes_version=$KUBERNETES_VERSION --tag managed_by_osism $IMGREG_EXTRA --file $UBU_IMG.$FMT $UBU_IMG_NM &
+  openstack image create --disk-format $FMT --min-ram 1024 --min-disk $DISKSZ --property image_build_date="$IMGDATE" --property image_original_user=ubuntu --property architecture=x86_64 --property hypervisor_type=kvm --property os_distro=ubuntu --property os_version="20.04" --property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_rng_model=virtio --property image_source=$IMAGESRC --property kubernetes_version=$KUBERNETES_VERSION --tag managed_by_osism $IMGREG_EXTRA --file $UBU_IMG.$FMT $UBU_IMG_NM  </dev/null &
+  CPID=$!
   sleep 5
   echo "Waiting for image $UBU_IMG_NM: "
   let -i ctr=0
@@ -47,5 +48,6 @@ if test -z "$CAPIIMG"; then
     echo "ERROR: Image $UBU_IMG_NM not found" 1>&2
     exit 2
   fi
+  # wait $CPID
   rm $UBU_IMG.$FMT
 fi

--- a/terraform/files/bin/upload_capi_image.sh
+++ b/terraform/files/bin/upload_capi_image.sh
@@ -29,8 +29,9 @@ if test -z "$CAPIIMG"; then
     qemu-img convert $UBU_IMG.qcow2 -O raw -S 4k $UBU_IMG.raw && rm $UBU_IMG.qcow2 || exit 1
   fi
   #TODO min-disk, min-ram, other std. image metadata
+  mkdir -p ~/tmp
   echo "Creating image $UBU_IMG_NM from $UBU_IMG.$FMT"
-  openstack image create --disk-format $FMT --min-ram 1024 --min-disk $DISKSZ --property image_build_date="$IMGDATE" --property image_original_user=ubuntu --property architecture=x86_64 --property hypervisor_type=kvm --property os_distro=ubuntu --property os_version="20.04" --property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_rng_model=virtio --property image_source=$IMAGESRC --property kubernetes_version=$KUBERNETES_VERSION --tag managed_by_osism $IMGREG_EXTRA --file $UBU_IMG.$FMT $UBU_IMG_NM  </dev/null &
+  nohup openstack image create --disk-format $FMT --min-ram 1024 --min-disk $DISKSZ --property image_build_date="$IMGDATE" --property image_original_user=ubuntu --property architecture=x86_64 --property hypervisor_type=kvm --property os_distro=ubuntu --property os_version="20.04" --property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi --property hw_rng_model=virtio --property image_source=$IMAGESRC --property kubernetes_version=$KUBERNETES_VERSION --tag managed_by_osism $IMGREG_EXTRA --file $UBU_IMG.$FMT $UBU_IMG_NM  > ~/tmp/img-create-$UBU_IMG_NM.out &
   CPID=$!
   sleep 5
   echo "Waiting for image $UBU_IMG_NM: "

--- a/terraform/files/bin/upload_capi_image.sh
+++ b/terraform/files/bin/upload_capi_image.sh
@@ -12,6 +12,7 @@ IMGREG_EXTRA=$(yq eval '.OPENSTACK_IMAGE_REGISTRATION_EXTRA_FLAGS' $CCCFG)
 VERSION_CAPI_IMAGE=$(echo $KUBERNETES_VERSION | sed 's/\.[[:digit:]]*$//g')
 UBU_IMG=ubuntu-2004-kube-$KUBERNETES_VERSION
 
+WAITLOOP=64
 #download/upload image to openstack
 CAPIIMG=$(openstack image list --name $UBU_IMG_NM)
 IMGURL=https://minio.services.osism.tech/openstack-k8s-capi-images
@@ -36,7 +37,7 @@ if test -z "$CAPIIMG"; then
   sleep 5
   echo "Waiting for image $UBU_IMG_NM: "
   let -i ctr=0
-  while test $ctr -le 64; do
+  while test $ctr -le $WAITLOOP; do
     CAPIIMG=$(openstack image list --name $UBU_IMG_NM -f value -c ID -c Status)
     STATUS="${CAPIIMG##* }"
     if test "$STATUS" = "saving" -o "$STATUS" = "active"; then break; fi
@@ -45,7 +46,7 @@ if test -z "$CAPIIMG"; then
     sleep 10
   done
   echo " $CAPIIMG"
-  if test $ctr -ge 60; then
+  if test $ctr -ge $WAITLOOP; then
     echo "ERROR: Image $UBU_IMG_NM not found" 1>&2
     exit 2
   fi


### PR DESCRIPTION
In `upload_capi_image.sh`, the openstack client is run in the background for the image registration process, as it can take a long time and we want to proceed with other things in parallel.
When this is used during the initial creation of the cluster management host (with terraform), the ssh connection from terraform might end prior to the openstack client having completed the registration and upload. The ssh connection end results in a SIGHUP to the started processes and thus can result in killing the openstack client during the upload. This results in the image staying in the `queued` state and never turning to active.
Using nohup resolves this issue.

This fixes issue #206.
Should be added to v3.x and v3.0.x.

Signed-off-by: Kurt Garloff <kurt@garloff.de>