### PR TITLE
Make sure we wait longer for new clusters (#208)

### DIFF
--- a/terraform/files/bin/create_cluster.sh
+++ b/terraform/files/bin/create_cluster.sh
@@ -106,9 +106,10 @@ kubectl apply -f ~/${CLUSTER_NAME}/${CLUSTER_NAME}-config.yaml || exit 3
 
 #Waiting for Clusterstate Ready
 echo "# Waiting for Cluster=Ready"
+sync; sleep 2
 #wget https://gx-scs.okeanos.dev --quiet -O /dev/null
 #ping -c1 -w2 9.9.9.9 >/dev/null 2>&1
-if test "$CLUSTER_EXISTS" = "1"; then sleep 12; fi
+if test "$CLUSTER_EXISTS" != "1"; then sleep 12; fi
 kubectl wait --timeout=5s --for=condition=certificatesavailable kubeadmcontrolplanes --selector=cluster.x-k8s.io/cluster-name=${CLUSTER_NAME} >/dev/null 2>&1 || sleep 25
 kubectl wait --timeout=15m --for=condition=certificatesavailable kubeadmcontrolplanes --selector=cluster.x-k8s.io/cluster-name=${CLUSTER_NAME} || exit 1
 kubectl wait --timeout=5m --for=condition=Ready machine -l cluster.x-k8s.io/control-plane || exit 4


### PR DESCRIPTION
There was logic to ensure we wait longer for new clusters, as the
control plane we wait does not even exist if we check too early,
so the script may error out.
Unfortunately, the logic was reversed, which is fixed now.

Should be backported to 3.x and 3.0.x after more testing.

Signed-off-by: Kurt Garloff <kurt@garloff.de>