### PR TITLE
Improve attaching/detaching NICS

### DIFF
--- a/terraform/files/bin/add_cluster-network.sh
+++ b/terraform/files/bin/add_cluster-network.sh
@@ -22,7 +22,9 @@ findnewnic()
 	return 1
 }
 
-MGMT=$(openstack server list --name "$PREFIX-mgmtcluster" -f value -c Name)
+MGMT="$PREFIX-mgmtcluster"
+# FIXME: We already know the name ($PREFIX-mgmtcluster)
+#MGMT=$(openstack server list --name "$PREFIX-mgmtcluster" -f value -c Name)
 openstack server add network $MGMT k8s-clusterapi-cluster-default-$CLUSTER_NAME || exit
 WAIT=0
 while test $WAIT -lt 30; do

--- a/terraform/files/bin/delete_cluster.sh
+++ b/terraform/files/bin/delete_cluster.sh
@@ -35,7 +35,10 @@ if grep '^ *OPENSTACK_ANTI_AFFINITY: true' $CCCFG >/dev/null 2>&1; then
 		openstack server group delete $SRVGRP_WORKER $SRVGRP_CONTROLLER
 	fi
 fi
+# Detach network interface (if ever attached)
+remove_cluster-network.sh "$CLUSTER_NAME" >/dev/null || true
 # Tell capi to clean up
+# TODO: Do this with timeout, possibly do some additional diagnostics to help with clean up
 kubectl delete cluster "$CLUSTER_NAME"
 kubectl config delete-context "$CLUSTER_NAME-admin@$CLUSTER_NAME"
 kubectl config delete-user "$CLUSTER_NAME-admin"

--- a/terraform/files/bin/remove_cluster-network.sh
+++ b/terraform/files/bin/remove_cluster-network.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 export KUBECONFIG=~/.kube/config
+. ~/.capi-settings
 . ~/bin/cccfg.inc
 
-#
-MGMT=$(openstack server list --name ".*\-mgmtcluster" -f value -c Name)
+# Determine mgmtserver networks
+MGMT="$PREFIX-mgmtcluster"
+MGMTNET=$(openstack server list --name "$MGMT" -f value -c Networks)
+NET=$(echo "$MGMTNET" | grep "k8s-clusterapi-cluster-default-$CLUSTER_NAME=" | sed "s/.*k8s-clusterapi-cluster-default-$CLUSTER_NAME=\([0-9a-f:\.]*\).*\$/\1/")
+if test -z "$NET"; then echo "No network to remove ..."; exit 1; fi
+NIC=$(ip addr | grep -B4 "inet $NET/" | grep '^[0-9]' | sed 's/^[0-9]*: \([^: ]*\): .*$/\1/')
+
 #sudo ip link set dev ens8 down
-echo "Removing NIC ..."
+echo "Removing NIC $NIC $NET ..."
 openstack server remove network $MGMT k8s-clusterapi-cluster-default-$CLUSTER_NAME || exit
 


### PR DESCRIPTION
add_cluster-network.sh: Save unnecessary server list calls:
  We know the name of the -mgmtcluster host.
remove_cluster-network.sh: Determine need to delete NIC and
  determine net and NIC name. Exit if nothing needs to be done.
delete_cluster.sh: Call remove_cluster-network.sh, just in case
  some cleanup is needed. It's harmless if not. If it is, it helps
  us to ensure that kubectl delete cluster can succeed.

Signed-off-by: Kurt Garloff <kurt@garloff.de>