### PR TITLE
:bug: fixes kubernetes versions

### DIFF
--- a/terraform/files/bin/openstack-kube-versions.inc
+++ b/terraform/files/bin/openstack-kube-versions.inc
@@ -2,12 +2,12 @@
 # (c) Kurt Garloff <kurt@garloff.de>, 3/2022
 # SPDX-License-Identifier: CC-BY-SA-4.0
 # Images from https://minio.services.osism.tech/openstack-k8s-capi-images
-k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.12" "v1.22.9" "v1.23.6", "v1.24.0")
+k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.12" "v1.22.9" "v1.23.6" "v1.24.0")
 # OCCM, CCM-RBAC, Cinder CSI, Cinder-Snapshot (TODO: Manila CSI)
-occm_versions=(""         ""       "v1.21.1" "v1.21.1" "v1.22.1" "v1.23.1", "v1.24.0")
-#ccmr_versions=(""        ""        ""        ""        "v1.22.1" "v1.23.1", "v1.24.0")
-ccmr_versions=(""        ""        "v1.22.1" "v1.22.1" "v1.22.1" "v1.23.1", "v1.24.0")
-ccsi_versions=(""        ""        "v1.20.5" "v1.21.1" "v1.22.1" "v1.23.1", "v1.24.0")
+occm_versions=(""         ""       "v1.21.1" "v1.21.1" "v1.22.1" "v1.23.1" "v1.24.0")
+#ccmr_versions=(""        ""        ""        ""        "v1.22.1" "v1.23.1" "v1.24.0")
+ccmr_versions=(""        ""        "v1.22.1" "v1.22.1" "v1.22.1" "v1.23.1" "v1.24.0")
+ccsi_versions=(""        ""        "v1.20.5" "v1.21.1" "v1.22.1" "v1.23.1" "v1.24.0")
 min_snapshot_master="v1.21.0"
 
 # Convert vxx.yy.zz to the number xxyyzz. Also works for z.y.z (0x0y0z).


### PR DESCRIPTION
Removes a comma in the list of supported k8s versions.
Bug was found while debugging the occm which couldn't be deployed on v1.23.1, because of a wrong constructed path due to the comma.