### PR TITLE
Add k8s-cluster-openstack-provider 0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `image` | | SCS | `Ubuntu 20.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
 `clusterapi_version` | | SCS | `1.0.5` | Version of the cluster-API incl. `clusterctl`
-`capi_openstack_version` | | SCS | `0.5.3` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
+`capi_openstack_version` | | SCS | `0.6.2` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
 
 Parameters controlling both management node creation and cluster creation:
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "clusterapi_version" {
 variable "capi_openstack_version" {
   description = "desired version of the OpenStack cluster-api provider"
   type        = string
-  default     = "0.5.3"
+  default     = "0.6.2"
 }
 
 variable "kubernetes_version" {


### PR DESCRIPTION
Deploy k8s-cluster-api-providerk8s-cluster-api-provider with 

kubernetes-sigs/cluster-api-provider-openstack  release 0.6.2


Signed-off-by: Mathias Fechner <fechner@osism.tech>