### PR TITLE
Source ~/.bash_aliases from some scripts.

### DIFF
--- a/terraform/files/bin/cleanup.sh
+++ b/terraform/files/bin/cleanup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # cleanup.sh
 
+# Source .bash_aliases in case we are called from non-interactive bash (Makefile)
+source ~/.bash_aliases
+
 export KUBECONFIG=~/.kube/config
 kubectl config use-context kind-kind
 CLUSTERS=$(kubectl get clusters | grep -v '^NAME' | awk '{ print $1; }')

--- a/terraform/files/bin/delete_cluster.sh
+++ b/terraform/files/bin/delete_cluster.sh
@@ -70,6 +70,7 @@ fi
 # Clean up appcred stuff (for new style appcred mgmt)
 if grep '^OLD_OPENSTACK_CLOUD:' $CCCFG >/dev/null 2>&1; then
   # Remove from clouds.yaml
+  mkdir -p ~/tmp
   echo "Removing application credential $PREFIX-$CLUSTER_NAME-appcred ..."
   OS_CLOUD="$PREFIX-$CLUSTER_NAME" print-cloud.py -x -s >~/tmp/clouds-no-$OS_CLOUD.yaml || exit 5
   cp -p ~/.config/openstack/clouds.yaml ~/.config/openstack/clouds.yaml.$OS_CLOUD

--- a/terraform/files/bin/deploy_cluster_api.sh
+++ b/terraform/files/bin/deploy_cluster_api.sh
@@ -3,6 +3,8 @@
 ##    desc: a helper for deploy a workload cluster on mgmt cluster
 ## license: Apache-2.0
 
+# Source .bash_aliases in case we are called from non-interactive bash (Makefile)
+source ~/.bash_aliases
 # variables
 . ~/.capi-settings
 

--- a/terraform/files/bin/deploy_cluster_api.sh
+++ b/terraform/files/bin/deploy_cluster_api.sh
@@ -3,8 +3,6 @@
 ##    desc: a helper for deploy a workload cluster on mgmt cluster
 ## license: Apache-2.0
 
-# Source .bash_aliases in case we are called from non-interactive bash (Makefile)
-source ~/.bash_aliases
 # variables
 . ~/.capi-settings
 
@@ -14,6 +12,11 @@ echo "# install clusterctl $CLUSTERAPI_VERSION"
 # TODO: Check signature
 sudo curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v$CLUSTERAPI_VERSION/clusterctl-linux-$ARCH -o /usr/local/bin/clusterctl
 sudo chmod +x /usr/local/bin/clusterctl
+
+# Source .bash_aliases in case we are called from non-interactive bash (Makefile)
+# This does not seem to be strictly needed for deploy_cluster_api.sh right now.
+# We have moved it until after installation of clusterctl to avoid a cosmetic error.
+source ~/.bash_aliases
 
 # get the clusterctl version
 echo "show the clusterctl version:"

--- a/terraform/files/bin/sonobuoy.sh
+++ b/terraform/files/bin/sonobuoy.sh
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Source .bash_aliases in case we are called from non-interactive bash (Makefile)
+# This does not seem to be strictly needed for sonobuoy.sh right now.
 source ~/.bash_aliases
 
 unset TZ

--- a/terraform/files/bin/sonobuoy.sh
+++ b/terraform/files/bin/sonobuoy.sh
@@ -6,6 +6,9 @@
 # (c) Kurt Garloff <garloff@osb-alliance.com>
 # SPDX-License-Identifier: Apache-2.0
 #
+# Source .bash_aliases in case we are called from non-interactive bash (Makefile)
+source ~/.bash_aliases
+
 unset TZ
 export LC_ALL=POSIX
 if ! test -x /usr/local/bin/sonobuoy; then


### PR DESCRIPTION
We need to do this when these scripts are invoked remotely (via ssh from
the Makefile), as non-interactive shells do not read ~/.bashrc.

Do this for cleanup.sh, deploy_cluster_api.sh and sonobuoy.sh which are
the only scripts called directly from the Makefile AFAICS.

This should address issue #240.

Signed-off-by: Kurt Garloff <kurt@garloff.de>