### PR TITLE
Latest k8s versions: 1.21.14, 1.22.12, 1.23.9, 1.24.2.

### DIFF
--- a/terraform/files/bin/openstack-kube-versions.inc
+++ b/terraform/files/bin/openstack-kube-versions.inc
@@ -2,7 +2,7 @@
 # (c) Kurt Garloff <kurt@garloff.de>, 3/2022
 # SPDX-License-Identifier: CC-BY-SA-4.0
 # Images from https://minio.services.osism.tech/openstack-k8s-capi-images
-k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.12" "v1.22.9" "v1.23.6" "v1.24.0")
+k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.14" "v1.22.12" "v1.23.9" "v1.24.2")
 # OCCM, CCM-RBAC, Cinder CSI, Cinder-Snapshot (TODO: Manila CSI)
 occm_versions=(""         ""       "v1.21.1" "v1.21.1" "v1.22.1" "v1.23.1" "v1.24.0")
 #ccmr_versions=(""        ""        ""        ""        "v1.22.1" "v1.23.1" "v1.24.0")


### PR DESCRIPTION
Signed-off-by: Kurt Garloff <kurt@garloff.de>