### PR TITLE
Feat/capi template update

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `kind_flavor` | | SCS | `SCS-1V:4:20` | Flavor to be used for the k8s capi mgmt node
 `image` | | SCS | `Ubuntu 20.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
-`clusterapi_version` | | SCS | `1.0.5` | Version of the cluster-API incl. `clusterctl`
+`clusterapi_version` | | SCS | `1.1.4` | Version of the cluster-API incl. `clusterctl`
 `capi_openstack_version` | | SCS | `0.6.2` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
 
 Parameters controlling both management node creation and cluster creation:
@@ -417,7 +417,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `node_cidr` | `NODE_CIDR` | SCS | `10.8.0.0/20` | IPv4 address range (CIDR notation) for workload nodes
 `use_cilium` | `USE_CILIUM` | SCS | `false` | Use cilium as CNI instead of calico
 `calico_version` | | SCS | `v3.22.1` | Version of the Calico CNI provider (ignored if `use_cilium` is set)
-`kubernetes_version` | `KUBERNETES_VERSION` | capo | `v1.22.x` | Kubernetes version deployed into workload cluster (`.x` means latest patch release)
+`kubernetes_version` | `KUBERNETES_VERSION` | capo | `v1.23.x` | Kubernetes version deployed into workload cluster (`.x` means latest patch release)
 ` ` | `OPENSTACK_IMAGE_NAME` | capo | `ubuntu-capi-image-${KUBERNETES_VERION}` | Image name for k8s controller and worker nodes
 `kube_image_raw` | `OPENSTACK_IMAGE_RAW` | SCS | `true` | Register images in raw format (instead of qcow2), good for ceph COW
 `image_registration_extra_flags` | `OPENSTACK_IMAGE_REGISTATION_EXTRA_FLAGS` | SCS | `""` | Extra flags passed during image registration

--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -150,7 +150,7 @@ cleanup_list router "" "" "$RTR"
 cleanup "security group" $CLUSTER
 #cleanup "image" ubuntu-capi-image
 cleanup volume $CLUSTER
-cleanup "server group" "k8s-capi-$CLUSTER"
+cleanup "server group" "$CAPIPRE-$CLUSTER"
 cleanup "application credential" "$CAPIPRE-$CLUSTER-appcred"
 
 # Continue with capi control plane

--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -95,7 +95,7 @@ cleanup()
 # main
 if test "$1" == "--verbose"; then VERBOSE=1; shift; fi
 if test "$1" == "--full"; then FULL=1; shift; fi
-if test -z "$1"; then CLUSTER="k8s-clusterapi"; else CLUSTER="$1"; shift; fi
+if test -z "$1"; then CLUSTER="testcluster"; else CLUSTER="$1"; shift; fi
 if test -z "$1"; then CAPIPRE="capi"; else CAPIPRE="$1"; shift; fi
 
 # For full cleanup, delete CAPI mgmt server first

--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -97,6 +97,8 @@ if test "$1" == "--verbose"; then VERBOSE=1; shift; fi
 if test "$1" == "--full"; then FULL=1; shift; fi
 if test -z "$1"; then CLUSTER="testcluster"; else CLUSTER="$1"; shift; fi
 if test -z "$1"; then CAPIPRE="capi"; else CAPIPRE="$1"; shift; fi
+CAPIPRE2="k8s-clusterapi-cluster-default"
+CAPIPRE3="k8s-cluster-default"
 
 # For full cleanup, delete CAPI mgmt server first
 if test "$FULL" == "1"; then
@@ -134,29 +136,31 @@ if test -n "$NOCASCADE"; then
 else
 	cleanup_list loadbalancer 1 "--cascade" "$LBS"
 fi
-cleanup server $CLUSTER
-cleanup port $CLUSTER
-RTR=$(resourcelist router $CLUSTER)
-SUBNETS=$(resourcelist subnet $CLUSTER)
+cleanup server $CAPIPRE-$CLUSTER
+cleanup port $CAPIPRE-$CLUSTER
+RTR=$(resourcelist router $CAPIPRE2-$CLUSTER)
+SUBNETS=$(resourcelist subnet $CAPIPRE2-$CLUSTER)
 if test -n "$RTR" -a -n "$SUBNETS"; then
 	echo $OPENSTACK router remove subnet $RTR $SUBNETS 1>&2
 	$OPENSTACK router remove subnet $RTR $SUBNETS
 fi
 cleanup_list subnet "" "" "$SUBNETS"
-#cleanup subnet $CLUSTER
-cleanup network $CLUSTER
-#cleanup router $CLUSTER
+#cleanup subnet $CAPIPRE2-$CLUSTER
+cleanup network $CAPIPRE2-$CLUSTER
+#cleanup router $CAPIPRE2-$CLUSTER
 cleanup_list router "" "" "$RTR"
-cleanup "security group" $CLUSTER
+cleanup "security group" $CAPIPRE3-$CLUSTER
+cleanup "security group" $CAPIPRE-$CLUSTER-cilium
 #cleanup "image" ubuntu-capi-image
-cleanup volume $CLUSTER
+# The PVC volumes are NOT deleted here
+cleanup volume $CAPIPRE-$CLUSTER
 cleanup "server group" "$CAPIPRE-$CLUSTER"
 cleanup "application credential" "$CAPIPRE-$CLUSTER-appcred"
 
 # Continue with capi control plane
 if test "$FULL" == "1"; then
-	RTR=$(resourcelist router ${CAPIPRE}-)
-	SUBNETS=$(resourcelist subnet ${CAPIPRE}-)
+	RTR=$(resourcelist router ${CAPIPRE}-rtr)
+	SUBNETS=$(resourcelist subnet ${CAPIPRE}-subnet)
 	if test -n "$RTR" -a -n "$SUBNETS"; then
 		echo $OPENSTACK router remove subnet $RTR $SUBNETS 1>&2
 		$OPENSTACK router remove subnet $RTR $SUBNETS
@@ -164,14 +168,14 @@ if test "$FULL" == "1"; then
 	if test -n "$SUBNETS"; then
 		cleanup port "" "--fixed-ip subnet=$SUBNETS"
 	fi
-	#cleanup subnet ${CAPIPRE}-
+	#cleanup subnet ${CAPIPRE}-subnet
 	cleanup_list subnet "" "" "$SUBNETS"
-	cleanup network ${CAPIPRE}-
+	cleanup network ${CAPIPRE}-net
 	#cleanup router ${CAPIPRE}-
 	cleanup_list router "" "" "$RTR"
-	cleanup "security group" ${CAPIPRE}-
+	cleanup "security group" ${CAPIPRE}-mgmt
 	cleanup "security group" allow-
-	cleanup keypair ${CAPIPRE}-
+	cleanup keypair ${CAPIPRE}-keypair
 	cleanup "application credential" ${CAPIPRE}-appcred
 	#cleanup volume pvc-
 	echo "Volumes from Cinder CSI left:"

--- a/terraform/files/bin/create_cluster.sh
+++ b/terraform/files/bin/create_cluster.sh
@@ -55,11 +55,11 @@ CONTROL_PLANE_MACHINE_COUNT=$(yq eval '.CONTROL_PLANE_MACHINE_COUNT' $CCCFG)
 # Implement anti-affinity with server groups
 if test "$CONTROL_PLANE_MACHINE_COUNT" -gt 0 &&  grep '^ *OPENSTACK_ANTI_AFFINITY: true' $CCCFG >/dev/null 2>&1; then
 	SRVGRP=$(openstack server group list -f value)
-	SRVGRP_CONTROLLER=$(echo "$SRVGRP" | grep "k8s-capi-${CLUSTER_NAME}-controller" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
-	SRVGRP_WORKER=$(echo "$SRVGRP" | grep "k8s-capi-${CLUSTER_NAME}-worker" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
+	SRVGRP_CONTROLLER=$(echo "$SRVGRP" | grep "${PREFIX}-${CLUSTER_NAME}-controller" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
+	SRVGRP_WORKER=$(echo "$SRVGRP" | grep "${PREFIX}-${CLUSTER_NAME}-worker" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
 	if test -z "$SRVGRP_CONTROLLER"; then
-		SRVGRP_CONTROLLER=$(openstack --os-compute-api-version 2.15 server group create --policy anti-affinity -f value -c id k8s-capi-${CLUSTER_NAME}-controller)
-		SRVGRP_WORKER=$(openstack --os-compute-api-version 2.15 server group create --policy soft-anti-affinity -f value -c id k8s-capi-${CLUSTER_NAME}-worker)
+		SRVGRP_CONTROLLER=$(openstack --os-compute-api-version 2.15 server group create --policy anti-affinity -f value -c id ${PREFIX}-${CLUSTER_NAME}-controller)
+		SRVGRP_WORKER=$(openstack --os-compute-api-version 2.15 server group create --policy soft-anti-affinity -f value -c id ${PREFIX}-${CLUSTER_NAME}-worker)
 	fi
 	echo "Adding server groups $SRVGRP_CONTROLLER and $SRVGRP_WORKER to $CCCFG"
 	if test -n "$SRVGRP_CONTROLLER"; then

--- a/terraform/files/bin/delete_cluster.sh
+++ b/terraform/files/bin/delete_cluster.sh
@@ -30,8 +30,8 @@ done
 # Delete server groups (if any)
 if grep '^ *OPENSTACK_ANTI_AFFINITY: true' $CCCFG >/dev/null 2>&1; then
 	SRVGRP=$(openstack server group list -f value)
-	SRVGRP_CONTROLLER=$(echo "$SRVGRP" | grep "k8s-capi-${CLUSTER_NAME}-controller" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
-	SRVGRP_WORKER=$(echo "$SRVGRP" | grep "k8s-capi-${CLUSTER_NAME}-worker" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
+	SRVGRP_CONTROLLER=$(echo "$SRVGRP" | grep "${PREFIX}-${CLUSTER_NAME}-controller" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
+	SRVGRP_WORKER=$(echo "$SRVGRP" | grep "${PREFIX}-${CLUSTER_NAME}-worker" | sed 's/^\([0-9a-f\-]*\) .*$/\1/')
 	if test -n "$SRVGRP_WORKER" -o -n "$SRVGRP_CONTROLLER"; then
 		openstack server group delete $SRVGRP_WORKER $SRVGRP_CONTROLLER
 	fi
@@ -60,7 +60,7 @@ if test $RC != 0; then
 		openstack port delete $id
 	done < <(echo "$PORTS")
 fi
-openstack security group delete k8s-cluster-${CLUSTER_NAME}-cilium >/dev/null 2>&1 || true
+openstack security group delete ${PREFIX}-${CLUSTER_NAME}-cilium >/dev/null 2>&1 || true
 if test $RC != 0; then
 	timeout 150 kubectl delete cluster "$CLUSTER_NAME"
 	# Non existent cluster means success

--- a/terraform/files/bin/enable-cilium-sg.sh
+++ b/terraform/files/bin/enable-cilium-sg.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 . ~/bin/cccfg.inc
-SGS=$(openstack security group list -f value -c ID -c Name | grep "k8s-cluster-${CLUSTER_NAME}-cilium")
+SGS=$(openstack security group list -f value -c ID -c Name | grep "${PREFIX}-${CLUSTER_NAME}-cilium")
 if test -z "$SGS"; then
-    SGS=$(openstack security group create k8s-cluster-${CLUSTER_NAME}-cilium -f value -c id -c name)
+    SGS=$(openstack security group create ${PREFIX}-${CLUSTER_NAME}-cilium -f value -c id -c name)
     # Note: Silium connectivity test will requires tcp/3xxxx/EchoOther tcp/3xxxx/EchoSame
     # See ports with k get svc -A
     # Should this really be required?
@@ -15,7 +15,7 @@ if test -z "$SGS"; then
 	port=${port%/*}
 	if test "${port%:*}" == "$port"; then port="$port:$port"; fi
 	# Note: we could instead use --remote-ip ${NODE_CIDR} -- less secure, but better performance
-	openstack security group rule create --description "capi $CLUSTER_NAME $desc" --ingress --ethertype IPv4 --proto $prot --dst-port $port --remote-group $SG $SG
+	openstack security group rule create --description "$PREFIX $CLUSTER_NAME $desc" --ingress --ethertype IPv4 --proto $prot --dst-port $port --remote-group $SG $SG
     done
 fi
 # SD is consumed in cluster-template.yaml

--- a/terraform/files/bin/signer.sh
+++ b/terraform/files/bin/signer.sh
@@ -90,7 +90,7 @@ checkvalidity()
 	HNM2=${SAN#*DNS:}; HNM2=${HNM2%%,*}
 	IP=${SAN#*,}; IP=${IP# IP Address:}
 	if test -z "$HNM2" -o -z "$IP"; then echo "Parsing error"; return 1; fi
-	echo "Cert request for $HNM2 ($IP):"
+	echo "Cert request $1 for $HNM2 ($IP):"
 	OST=$(openstack server list --name="$HNM2" -f value -c Networks)
 	RC=$?
 	if test "$RC" != 0; then echo "Not found"; return $$c; fi
@@ -104,7 +104,7 @@ checkvalidity()
 while read req age signer requestor status; do
 	if test "$status" = "Approved,Issued"; then continue
 	elif test "$status" = "Approved"; then sign $req; continue
-	elif test "$status" != "Pending"; then continue
+	elif test "$status" != "Pending"; then echo "Unexpected $req status $status"; continue
 	fi
 	#FIXME: Should ask openstack whether DNS nama and IP match ....
 	if test "$ONLYAPPROVED" = "1"; then continue; fi

--- a/terraform/files/bin/signer.sh
+++ b/terraform/files/bin/signer.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# k8s signer
+# (c) Kurt Garloff <garloff@osb-alliance.com>, 8/2022
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+usage()
+{
+	echo "Usage: signer.sh CLUSTERNAME [OPTIONS]"
+	echo "Options: -a => only sign approved CSRs"
+	echo "         -f => approve and sign all"
+	echo "Default is to ask for unapproved"
+	exit 1
+}
+
+
+if test -z "$1"; then usage; fi
+
+CTX="--context=$1-admin@$1"
+shift
+if test "$1" == "-a"; then ONLYAPPROVED=1; shift; fi
+if test "$1" == "-f"; then FORCEAPPROVE=1; shift; fi
+
+if test ! -r ca.crt -o ! -r ca.key; then
+	echo "Need ca.crt and ca.key in current directory"
+	exit 2
+fi
+
+if test ! -r server-signing-config.json; then cat > server-signing-config.json <<EOT
+{
+    "signing": {
+        "default": {
+            "usages": [
+                "digital signature",
+                "key encipherment",
+                "server auth"
+            ],
+            "expiry": "8784h",
+            "ca_constraint": {
+                "is_ca": false
+            }
+        }
+    }
+}
+EOT
+fi
+
+sign()
+{
+	CERTAPI=v1beta1
+	REQ=$(kubectl $CTX get csr $1 -o jsonpath='{.spec.request}' | base64 --decode)
+	OSSLINFO=$(echo "$REQ" | openssl req -noout -text -in -)
+	echo "Signing $1: $OSSLINFO"
+	SIGNED=$(echo "$REQ" | cfssl sign -ca ca.crt -ca-key ca.key -config server-signing-config.json - | cfssljson -bare signed-$1)
+	kubectl $CTX get csr $1 -o json | jq '.status.certificate = "'$(base64 signed-$1.pem | tr -d '\n')'"' | \
+		kubectl $CTX replace --raw /apis/certificates.k8s.io/$CERTAPI/certificatesigningrequests/$1/status -f -
+}
+
+
+while read req age signer requestor status; do
+	if test "$status" = "Approved,Issued"; then continue
+	elif test "$status" = "Approved"; then sign $req
+	elif test "$status" != "Pending"; then continue
+	fi
+	#FIXME: Should ask openstack whether DNS nama and IP match ....
+	if test "$ONLYAPPROVED" = "1"; then continue; fi
+	if test "$FORCEAPPROVE" = "1"; then
+		echo "Force approval for $req ($requestor -> $signer / $age)"
+		kubectl $CTX certificate approve $req
+		sign $req
+		continue
+	fi
+	REQ=$(kubectl $CTX get csr $req -o jsonpath='{.spec.request}' | base64 --decode)
+	OSSLINFO=$(echo "$REQ" | openssl req -noout -text -in -)
+	echo -ne "$OSSLINFO\nApprove $req ($requestor -> $signer / $age)? "
+	read ans </dev/tty
+	if test "$ans" = "y" -o "$ans" = "Y" -o "$ans" = "1" -o "$ans" = "yes" -o "$ans" = "YES" -o "$ans" = "Yes"; then
+		kubectl $CTX certificate approve $req
+		sign $req
+	fi
+done < <(kubectl $CTX get csr)
+

--- a/terraform/files/bin/signer.sh
+++ b/terraform/files/bin/signer.sh
@@ -2,6 +2,14 @@
 # k8s signer
 # (c) Kurt Garloff <garloff@osb-alliance.com>, 8/2022
 # SPDX-License-Identifier: CC-BY-SA-4.0
+#
+# Usage:
+# * Create a directory where you put the kubernetes ca.crt and .key.
+# * Go into this directory
+# * Calling signer.sh CLUSTERNAME will sign all CSRs that have been marked approved
+#   with the CA cert and push the cert back into k8s.
+# * For Pending requests, it will display and interactively ask, which can be
+#   changed using options -f and -a.
 
 usage()
 {
@@ -25,6 +33,9 @@ if test ! -r ca.crt -o ! -r ca.key; then
 	exit 2
 fi
 
+if ! type -p jq >/dev/null; then echo "Need jq installed"; exit 2; fi
+if ! type -p cfssl >/dev/null; then echo "Need cfssl installed"; exit 2; fi
+
 if test ! -r server-signing-config.json; then cat > server-signing-config.json <<EOT
 {
     "signing": {
@@ -46,19 +57,23 @@ fi
 
 sign()
 {
+	# FIXME: Need to determine API version
 	CERTAPI=v1beta1
-	REQ=$(kubectl $CTX get csr $1 -o jsonpath='{.spec.request}' | base64 --decode)
+	REQ=$(kubectl $CTX get csr $1 -o jsonpath='{.spec.request}' | base64 --decode) || exit 4
 	OSSLINFO=$(echo "$REQ" | openssl req -noout -text -in -)
 	echo "Signing $1: $OSSLINFO"
-	SIGNED=$(echo "$REQ" | cfssl sign -ca ca.crt -ca-key ca.key -config server-signing-config.json - | cfssljson -bare signed-$1)
+	echo "$REQ" | cfssl sign -ca ca.crt -ca-key ca.key -config server-signing-config.json - | cfssljson -bare signed-$1
+	if test "${PIPESTATUS[1]}" != "0"; then exit 5; fi
+	# Append issuer cert to have full trust chain
+	cat ca.crt >> signed-$1.pem
 	kubectl $CTX get csr $1 -o json | jq '.status.certificate = "'$(base64 signed-$1.pem | tr -d '\n')'"' | \
-		kubectl $CTX replace --raw /apis/certificates.k8s.io/$CERTAPI/certificatesigningrequests/$1/status -f -
+		kubectl $CTX replace --raw /apis/certificates.k8s.io/$CERTAPI/certificatesigningrequests/$1/status -f - || exit 6
 }
 
 
 while read req age signer requestor status; do
 	if test "$status" = "Approved,Issued"; then continue
-	elif test "$status" = "Approved"; then sign $req
+	elif test "$status" = "Approved"; then sign $req; continue
 	elif test "$status" != "Pending"; then continue
 	fi
 	#FIXME: Should ask openstack whether DNS nama and IP match ....

--- a/terraform/files/bin/signer.sh
+++ b/terraform/files/bin/signer.sh
@@ -12,6 +12,10 @@
 #   changed using options -f, -a and -u.
 # * -u asks the underlaying infra (OpenStack) whether hosts and IPs exist as requested
 #   in the CSr and judges the approval based on it.
+# You could run this in an endless loop (in tmux):
+#   while true; signer.sh CLUSTERNAME -u; sleep 30; done
+# Note that a proper CSR handler (in CAPI) is the real solution for valid server
+# certificates. Consider this script a PoC.
 
 usage()
 {
@@ -102,6 +106,9 @@ checkvalidity()
 }
 
 while read req age signer requestor status; do
+	# Skip header
+	if test "$req" = "NAME"; then continue; fi
+	# Status
 	if test "$status" = "Approved,Issued"; then continue
 	elif test "$status" = "Approved"; then sign $req; continue
 	elif test "$status" != "Pending"; then echo "Unexpected $req status $status"; continue

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -11,7 +11,7 @@ spec:
     serviceDomain: "cluster.local"
   infrastructureRef:
     #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
     kind: OpenStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -20,7 +20,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane
 ---
 #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -29,7 +29,9 @@ spec:
   identityRef:
     name: ${CLUSTER_NAME}-cloud-config
     kind: Secret
-  managedAPIServerLoadBalancer: true
+  #managedAPIServerLoadBalancer: true
+  apiServerLoadBalancer:
+    enabled: true
   managedSecurityGroups: true
   nodeCidr: ${NODE_CIDR}
   dnsNameservers: ${OPENSTACK_DNS_NAMESERVERS}
@@ -45,8 +47,8 @@ spec:
     infrastructureRef:
       kind: OpenStackMachineTemplate
       #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
-      name: "k8s-clusterapi-${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}"
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+      name: "${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}"
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
@@ -82,10 +84,10 @@ spec:
   version: "${KUBERNETES_VERSION}"
 ---
 #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: OpenStackMachineTemplate
 metadata:
-  name: k8s-clusterapi-${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}
+  name: ${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}
 spec:
   template:
     spec:
@@ -122,13 +124,13 @@ spec:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
       infrastructureRef:
-        name: "k8s-clusterapi-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}"
+        name: "${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}"
         #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
         kind: OpenStackMachineTemplate
 ---
 #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: OpenStackMachineTemplate
 metadata:
   name: k8s-clusterapi-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -48,7 +48,7 @@ spec:
       kind: OpenStackMachineTemplate
       #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
-      name: "${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}"
+      name: "${PREFIX}-${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}"
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
@@ -87,7 +87,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: OpenStackMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}
+  name: ${PREFIX}-${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}
 spec:
   template:
     spec:
@@ -102,12 +102,12 @@ spec:
       securityGroups:
         - name: allow-ssh
         - name: allow-icmp
-        - name: k8s-cluster-${CLUSTER_NAME}-cilium
+        - name: ${PREFIX}-${CLUSTER_NAME}-cilium
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: "${CLUSTER_NAME}-md-0-no1"
+  name: "${PREFIX}-${CLUSTER_NAME}-md-0-no1"
 spec:
   clusterName: "${CLUSTER_NAME}"
   replicas: ${WORKER_MACHINE_COUNT}
@@ -120,11 +120,11 @@ spec:
       failureDomain: ${OPENSTACK_FAILURE_DOMAIN}
       bootstrap:
         configRef:
-          name: "${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}"
+          name: "${PREFIX}-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}"
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
       infrastructureRef:
-        name: "${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}"
+        name: "${PREFIX}-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}"
         #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
         kind: OpenStackMachineTemplate
@@ -133,7 +133,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: OpenStackMachineTemplate
 metadata:
-  name: k8s-clusterapi-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}
+  name: ${PREFIX}-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}
 spec:
   template:
     spec:
@@ -148,12 +148,12 @@ spec:
       securityGroups:
         - name: allow-ssh
         - name: allow-icmp
-        - name: k8s-cluster-${CLUSTER_NAME}-cilium
+        - name: ${PREFIX}-${CLUSTER_NAME}-cilium
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}
+  name: ${PREFIX}-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}
 spec:
   template:
     spec:

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,7 @@ variable "calico_version" {
 variable "clusterapi_version" {
   description = "desired version of cluster-api"
   type        = string
-  default     = "1.0.5"
+  default     = "1.1.4"
 }
 
 variable "capi_openstack_version" {
@@ -70,7 +70,7 @@ variable "capi_openstack_version" {
 variable "kubernetes_version" {
   description = "desired kubernetes version for the workload cluster"
   type        = string
-  default     = "v1.22.x"
+  default     = "v1.23.x"
 }
 
 variable "kube_image_raw" {


### PR DESCRIPTION
Update external cluster-template to use alpha5 APIversions and adjust naming of resources to upstream.
However, keep PREFIX consistently in front of OpenStack resources where we can.
Network, Subnets and Loadbalancers created from CAPO unfortunately don't comply.
Probably, we'll need to reflect this in the cleanup script.