### PR TITLE
cosmetic: used should not have been transformed to u$(SED).

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -60,7 +60,7 @@ mycloud: environments/environment-$(ENVIRONMENT).tfvars
 
 gitchk:
 	@git diff -r origin/$(GITBRANCH) > git.diff
-	@if test -s git.diff; then echo "WARN: Local changes won't be u$(SED) on mgmtcluster. Commit and push them"; cat git.diff; fi
+	@if test -s git.diff; then echo "WARN: Local changes won't be used on mgmtcluster. Commit and push them"; cat git.diff; fi
 
 create: init
 	@touch .deploy.$(ENVIRONMENT)


### PR DESCRIPTION
This reverts a snippet from e7df2e5e.

Thanks for spotting, @matfecher!
https://github.com/SovereignCloudStack/k8s-cluster-api-provider/pull/254#discussion_r952345293

Signed-off-by: Kurt Garloff <kurt@garloff.de>