### PR TITLE
Upgrade to kind-v0.14.0.

### DIFF
--- a/terraform/files/bin/install_kind.sh
+++ b/terraform/files/bin/install_kind.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-KIND_VERSION=0.12.0
+KIND_VERSION=0.14.0
 sudo wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
 sudo chmod +x /usr/local/bin/kind
 kind create cluster


### PR DESCRIPTION
Uses kubernetes-v1.24.x with systemd cgroups driver.
Updated all components (go, crictl, kindnetd, haproxy, containerd, CNI, ...)

Signed-off-by: Kurt Garloff <kurt@garloff.de>