### PR TITLE
Update to k8s-v1.23.10, 1.24.4, 1.25.0.

### DIFF
--- a/terraform/files/bin/openstack-kube-versions.inc
+++ b/terraform/files/bin/openstack-kube-versions.inc
@@ -2,12 +2,12 @@
 # (c) Kurt Garloff <kurt@garloff.de>, 3/2022
 # SPDX-License-Identifier: CC-BY-SA-4.0
 # Images from https://minio.services.osism.tech/openstack-k8s-capi-images
-k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.14" "v1.22.12" "v1.23.9" "v1.24.2")
+k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.14" "v1.22.13" "v1.23.10" "v1.24.4" "v1.25.0")
 # OCCM, CCM-RBAC, Cinder CSI, Cinder-Snapshot (TODO: Manila CSI)
-occm_versions=(""         ""       "v1.21.1" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2")
-#ccmr_versions=(""        ""        ""        ""        "v1.22.1" "v1.23.4" "v1.24.2")
-ccmr_versions=(""        ""        "v1.22.1" "v1.22.1" "v1.22.1" "v1.23.4" "v1.24.2")
-ccsi_versions=(""        ""        "v1.20.5" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2")
+occm_versions=(""         ""       "v1.21.1" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2" "latest")
+#ccmr_versions=(""        ""        ""        ""        "v1.22.1" "v1.23.4" "v1.24.2" "latest")
+ccmr_versions=(""        ""        "v1.22.1" "v1.22.1" "v1.22.1" "v1.23.4" "v1.24.2" "latest")
+ccsi_versions=(""        ""        "v1.20.5" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2" "latest")
 min_snapshot_master="v1.21.0"
 
 # Convert vxx.yy.zz to the number xxyyzz. Also works for z.y.z (0x0y0z).


### PR DESCRIPTION
Use latest node images.

Signed-off-by: Kurt Garloff <kurt@garloff.de>