### PR TITLE
Address #269: Avoid using git accounts.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -41,7 +41,7 @@ TESTCLUSTER=$(shell ( grep '^testcluster_name' environments/environment-$(ENVIRO
 endif
 
 GITBRANCH=$(shell git branch | grep '^*' | $(SED) 's/^* //')
-GITREPO=$(shell git config --get remote.origin.url)
+GITREPO=$(shell git config --get remote.origin.url | sed 's%git@\([^:]*\):%https://\1/%')
 
 init:	mycloud
 	@if [ ! -d .terraform/plugins ]; then terraform init; fi


### PR DESCRIPTION
When making the git repo configurable that the automation in the cluster management hosts comes from (#266), we detected the existing git repo and pass it down from the Makefile.

However, for developers, there is a significant likelihood that they are using a clone checked out with their account git@github.com. This will not work on the management host, as the account is not deployed there.

So translate this to an anonymous https:// URL before passing down.

Signed-off-by: Kurt Garloff <kurt@garloff.de>