### PR TITLE
Only delete app cred if cleanup fully succeeded.

### DIFF
--- a/terraform/files/bin/delete_cluster.sh
+++ b/terraform/files/bin/delete_cluster.sh
@@ -79,7 +79,11 @@ if grep '^OLD_OPENSTACK_CLOUD:' $CCCFG >/dev/null 2>&1; then
   sed -i '/^OPENSTACK_CLOUD:/d' $CCCFG; sed -i 's/^OLD_OPENSTACK_CLOUD:/OPENSTACK_CLOUD:/' $CCCFG
   # Delete app cred
   OS_CLOUD=$(yq eval '.OPENSTACK_CLOUD' $CCCFG)
-  openstack application credential delete "$PREFIX-$CLUSTER_NAME-appcred" || RC=1
+  if test $RC = 0; then
+    openstack application credential delete "$PREFIX-$CLUSTER_NAME-appcred" || RC=1
+  else
+    echo "Please delete application credential $PREFIX-$CLUSTER_NAME-appcred once capo has cleaned everything up."
+  fi
 fi
 # TODO: Clean up ~/$CLUSTER_NAME
 exit $RC


### PR DESCRIPTION
When anything went wrong, we have k8s objects remaining with a reference to a cloud.conf that encodes the per-cluster application credentials. Once we remove them from OpenStack, they no longer work. Which makes cleaning up any remaining pieces from k8s capo extremely difficult.

So in case of failure, leave the app-cred available for OpenStack. We still remove it from clouds.yaml, as we don't need it there (and can recover it if really needed from cloud.conf).

Signed-off-by: Kurt Garloff <kurt@garloff.de>