### PR TITLE
Use meanwhile released v1.25.0 ccm/csi for k8s-v.1.25.

### DIFF
--- a/terraform/files/bin/openstack-kube-versions.inc
+++ b/terraform/files/bin/openstack-kube-versions.inc
@@ -4,10 +4,10 @@
 # Images from https://minio.services.osism.tech/openstack-k8s-capi-images
 k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.14" "v1.22.13" "v1.23.10" "v1.24.4" "v1.25.0")
 # OCCM, CCM-RBAC, Cinder CSI, Cinder-Snapshot (TODO: Manila CSI)
-occm_versions=(""         ""       "v1.21.1" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2" "latest")
-#ccmr_versions=(""        ""        ""        ""        "v1.22.1" "v1.23.4" "v1.24.2" "latest")
-ccmr_versions=(""        ""        "v1.22.1" "v1.22.1" "v1.22.1" "v1.23.4" "v1.24.2" "latest")
-ccsi_versions=(""        ""        "v1.20.5" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2" "latest")
+occm_versions=(""         ""       "v1.21.1" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2" "v1.25.0")
+#ccmr_versions=(""        ""        ""        ""        "v1.22.1" "v1.23.4" "v1.24.2" "v1.25.0")
+ccmr_versions=(""        ""        "v1.22.1" "v1.22.1" "v1.22.1" "v1.23.4" "v1.24.2" "v1.25.0")
+ccsi_versions=(""        ""        "v1.20.5" "v1.21.1" "v1.22.1" "v1.23.4" "v1.24.2" "v1.25.0")
 min_snapshot_master="v1.21.0"
 
 # Convert vxx.yy.zz to the number xxyyzz. Also works for z.y.z (0x0y0z).


### PR DESCRIPTION
We had used the head branch before which worked, but is a changing target.

Signed-off-by: Kurt Garloff <kurt@garloff.de>