### PR TITLE
Update to calico-v3.24.1 by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 ---|---|---|---|---
 `node_cidr` | `NODE_CIDR` | SCS | `10.8.0.0/20` | IPv4 address range (CIDR notation) for workload nodes
 `use_cilium` | `USE_CILIUM` | SCS | `false` | Use cilium as CNI instead of calico
-`calico_version` | | SCS | `v3.24.0` | Version of the Calico CNI provider (ignored if `use_cilium` is set)
+`calico_version` | | SCS | `v3.24.1` | Version of the Calico CNI provider (ignored if `use_cilium` is set)
 `kubernetes_version` | `KUBERNETES_VERSION` | capo | `v1.23.x` | Kubernetes version deployed into workload cluster (`.x` means latest patch release)
 ` ` | `OPENSTACK_IMAGE_NAME` | capo | `ubuntu-capi-image-${KUBERNETES_VERION}` | Image name for k8s controller and worker nodes
 `kube_image_raw` | `OPENSTACK_IMAGE_RAW` | SCS | `true` | Register images in raw format (instead of qcow2), good for ceph COW

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -13,7 +13,7 @@ image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
 # Settings for testcluster
 kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.23.x"
 kube_image_raw       = "<boolean>"      # defaults to "true"
-calico_version       = "<v3.xx.y>"	# defaults to "v3.22.1"
+calico_version       = "<v3.xx.y>"	# defaults to "v3.24.1"
 controller_flavor    = "<flavor>"       # defaults to SCS-2D:4:20s (use etcd tweaks if you only have SCS-2V:4:20 in multi-controller setups)
 worker_flavor        = "<flavor>"       # defaults to SCS-2V:4:20  (larger helps)
 controller_count     = <number>         # defaults to 1 (0 skips testcluster creation)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,7 +52,7 @@ variable "ssh_username" {
 variable "calico_version" {
   description = "desired version of calico"
   type        = string
-  default     = "v3.24.0"
+  default     = "v3.24.1"
 }
 
 variable "clusterapi_version" {


### PR DESCRIPTION
Bugfixes.

Signed-off-by: Kurt Garloff <kurt@garloff.de>