### PR TITLE
Install helm-3.9.4 on the management host.

### DIFF
--- a/terraform/files/bin/install_helm.sh
+++ b/terraform/files/bin/install_helm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Download and deploy helm
 
-HELMVER=3.8.1
+HELMVER=3.9.4
 OS=linux; ARCH=$(uname -m | sed 's/x86_64/amd64/')
 curl -LO https://get.helm.sh/helm-v${HELMVER}-$OS-$ARCH.tar.gz
 tar xvzf helm-v${HELMVER}-$OS-$ARCH.tar.gz


### PR DESCRIPTION
Up from 3.8.1. Supporting latest k8s and features.

Signed-off-by: Kurt Garloff <kurt@garloff.de>