### PR TITLE
Remove hint to CoC in R3 release notes

### DIFF
--- a/Release-Notes-R3.md
+++ b/Release-Notes-R3.md
@@ -324,6 +324,3 @@ These branches will receive updates until the end of April 2023.
 We appreciate contribution to strategy and implemention, please join
 our community -- or just leave input on the github issues and PRs.
 Have a look at our [contribution invitation](https://scs.community/contribute/).
-We also have worked on a [Code of Conduct](https://github.com/SovereignCloudStack/Docs/pull/26)
-to document the expected behavior of contributors and how we deal with
-cases where individuals fail to meet the expectation.


### PR DESCRIPTION
Should we really give that hint to the CoC in the release notes? I think this may sound a bit daunting – especially if we end the sentence by "failing to meet the expectations".