### PR TITLE
Upgrade to capi-v1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `kind_flavor` | | SCS | `SCS-1V:4:20` | Flavor to be used for the k8s capi mgmt node
 `image` | | SCS | `Ubuntu 20.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
-`clusterapi_version` | | SCS | `1.2.2` | Version of the cluster-API incl. `clusterctl`
+`clusterapi_version` | | SCS | `1.2.4` | Version of the cluster-API incl. `clusterctl`
 `capi_openstack_version` | | SCS | `0.6.3` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
 
 Parameters controlling both management node creation and cluster creation:

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,7 @@ variable "calico_version" {
 variable "clusterapi_version" {
   description = "desired version of cluster-api"
   type        = string
-  default     = "1.2.2"
+  default     = "1.2.4"
 }
 
 variable "capi_openstack_version" {


### PR DESCRIPTION
* Fix machine deployment deletion via ClusterClass

Upgrade to capi-v1.2.3

* ClusterClass topology with exact apiVersions improving CAPI upgrades.
* KCP tolerating control plane node taints; ability to create control plane nodes without taints.

Signed-off-by: Kurt Garloff <kurt@garloff.de>