### PR TITLE
Update default version to capi-v1.2.6, capo-v0.6.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,8 +440,8 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `kind_flavor` | | SCS | `SCS-1V:4:20` | Flavor to be used for the k8s capi mgmt node
 `image` | | SCS | `Ubuntu 20.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
-`clusterapi_version` | | SCS | `1.2.4` | Version of the cluster-API incl. `clusterctl`
-`capi_openstack_version` | | SCS | `0.6.3` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
+`clusterapi_version` | | SCS | `1.2.6` | Version of the cluster-API incl. `clusterctl`
+`capi_openstack_version` | | SCS | `0.6.4` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
 
 Parameters controlling both management node creation and cluster creation:
 

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -7,8 +7,8 @@ external             = "<external_network_name>"
 dns_nameservers      = [ "DNS_IP1", "DNS_IP2" ]	  # defaults to [ "5.1.66.255", "185.150.99.255" ] (FF MUC)
 kind_flavor          = "<flavor>"                 # defaults to SCS-1V:4:20  (larger does not hurt)
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"
-clusterapi_version   = "<1.x.y>"		  # defaults to "1.2.2"
-capi_openstack_version = "<0.x.y>"		  # defaults to "0.6.3"
+clusterapi_version   = "<1.x.y>"		  # defaults to "1.2.6"
+capi_openstack_version = "<0.x.y>"		  # defaults to "0.6.4"
 image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
 # Settings for testcluster
 kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.23.x"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,13 +58,13 @@ variable "calico_version" {
 variable "clusterapi_version" {
   description = "desired version of cluster-api"
   type        = string
-  default     = "1.2.4"
+  default     = "1.2.6"
 }
 
 variable "capi_openstack_version" {
   description = "desired version of the OpenStack cluster-api provider"
   type        = string
-  default     = "0.6.3"
+  default     = "0.6.4"
 }
 
 variable "kubernetes_version" {


### PR DESCRIPTION
Update to capo version v0.6.4:
* Implement conversion for OpenStackClusterTemplate CRD
* Fixed logger arguments

Update default capi version to v1.2.6:
* ClusterCacheTracker: Per cluster locking avoids unreachable clusters to block others
* kubekey provider
* finalizer reconciliation for TOpology MachineSets and MachineDeployments

Update default capi version to v1.2.5:
* Use registry.k8s.io images (rather than k8s.gcr.io)
* Avoid clusterctl move to change managedFields
* Run kubeadmconfig reconciliation after datasecretname setting
* go1.18.8 and bump dependencies to address CVEs.

Signed-off-by: Kurt Garloff <kurt@garloff.de>