### PR TITLE
Defaulting to nano by git is not our preference.

### DIFF
--- a/terraform/files/bin/bootstrap.sh
+++ b/terraform/files/bin/bootstrap.sh
@@ -38,6 +38,8 @@ source <( clusterctl completion bash )
 
 # Error code in prompt
 PS1="\${PS1%\\\\\$ } [\\\$?]\\\$ "
+# We may do git commits and nano feels unusual ...
+export VISUAL=/usr/bin/vim
 # eof
 EOF
 


### PR DESCRIPTION
So export VISUAL into the environment.

Signed-off-by: Kurt Garloff <kurt@garloff.de>