### PR TITLE
Default to Ubuntu 22.04 on management host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ environment | clusterctl.yaml | provenance | default |  meaning
 ---|---|---|---|---
 `prefix` | | SCS | `capi` | Prefix used for OpenStack resources for the capi mgmt node
 `kind_flavor` | | SCS | `SCS-1V:4:20` | Flavor to be used for the k8s capi mgmt node
-`image` | | SCS | `Ubuntu 20.04` | Image to be deployed for the capi mgmt node
+`image` | | SCS | `Ubuntu 22.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
 `clusterapi_version` | | SCS | `1.2.6` | Version of the cluster-API incl. `clusterctl`
 `capi_openstack_version` | | SCS | `0.6.4` | Version of the cluster-api-provider-openstack (needs to fit the capi version)

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -9,7 +9,7 @@ kind_flavor          = "<flavor>"                 # defaults to SCS-1V:4:20  (la
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"
 clusterapi_version   = "<1.x.y>"		  # defaults to "1.2.6"
 capi_openstack_version = "<0.x.y>"		  # defaults to "0.6.4"
-image                = "<glance_image>"		  # defaults to "Ubuntu 20.04"
+image                = "<glance_image>"		  # defaults to "Ubuntu 22.04"
 # Settings for testcluster
 kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.23.x"
 kube_image_raw       = "<boolean>"      # defaults to "true"

--- a/terraform/files/bin/prepare_openstack.sh
+++ b/terraform/files/bin/prepare_openstack.sh
@@ -3,6 +3,7 @@
 export OS_CLOUD=$(yq eval '.OPENSTACK_CLOUD' ~/cluster-defaults/clusterctl.yaml)
 
 #install Openstack CLI
+export NEEDRESTART_SUSPEND=1	# Ubu 22.04 bug
 sudo apt install -y python3-openstackclient python3-octaviaclient
 # fix bug 1876317
 sudo patch -p2 -N -d /usr/lib/python3/dist-packages/keystoneauth1 < /tmp/fix-keystoneauth-plugins-unversioned.diff

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,7 +12,7 @@ variable "prefix" {
 variable "image" {
   description = "openstack glance image for nova instances"
   type        = string
-  default     = "Ubuntu 20.04"
+  default     = "Ubuntu 22.04"
 }
 
 variable "kind_flavor" {


### PR DESCRIPTION
It needed a workaround setting the env NEEDRESTART_SUSPEND=1, as apt install -y does not seem sufficient to prevent interaction desires from the system.

Signed-off-by: Kurt Garloff <kurt@garloff.de>