### PR TITLE
Move to kind-0.17.0 (k8s v1.25.3).

### DIFF
--- a/terraform/files/bin/install_kind.sh
+++ b/terraform/files/bin/install_kind.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-KIND_VERSION=0.14.0
+KIND_VERSION=0.17.0
 sudo wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
 sudo chmod +x /usr/local/bin/kind
 kind create cluster


### PR DESCRIPTION
This brings k8s-v1.25.3 Supports the capi-1.2+ and capo-0.6+ objects and containers well.

Signed-off-by: Kurt Garloff <kurt@garloff.de>