### PR TITLE
New openstack CLI tooling changed network output.

### DIFF
--- a/terraform/files/bin/remove_cluster-network.sh
+++ b/terraform/files/bin/remove_cluster-network.sh
@@ -7,6 +7,8 @@ export KUBECONFIG=~/.kube/config
 MGMT="$PREFIX-mgmtcluster"
 MGMTNET=$(openstack server list --name "$MGMT" -f value -c Networks)
 NET=$(echo "$MGMTNET" | grep "k8s-clusterapi-cluster-default-$CLUSTER_NAME=" | sed "s/.*k8s-clusterapi-cluster-default-$CLUSTER_NAME=\([0-9a-f:\.]*\).*\$/\1/")
+# New format
+if test -z "$NET"; then NET=$(echo "$MGMTNET" | grep "'k8s-clusterapi-cluster-default-$CLUSTER_NAME':" | sed "s/.*'k8s-clusterapi-cluster-default-$CLUSTER_NAME':[^']*'\([0-9a-f:\.]*\)'.*\$/\1/"); fi
 if test -z "$NET"; then echo "No network to remove ..."; exit 1; fi
 NIC=$(ip addr | grep -B4 "inet $NET/" | grep '^[0-9]' | sed 's/^[0-9]*: \([^: ]*\): .*$/\1/')
 


### PR DESCRIPTION
Rather than networkname=IP, IP we now have 'networkname': ['IP', 'IP'] as output from server list. Parse both.

Signed-off-by: Kurt Garloff <kurt@garloff.de>