### PR TITLE
Correct occm and ccsi image versions

### DIFF
--- a/terraform/files/bin/apply_cindercsi.sh
+++ b/terraform/files/bin/apply_cindercsi.sh
@@ -46,6 +46,7 @@ if test -n "$CCSI_VERSION"; then
   done
   # Note: We leave out the secret which we should already have
   cat cinder-csi-*-rbac-$CCSI_VERSION.yaml cinder-csi-*plugin-$CCSI_VERSION.yaml csi-cinder-driver-$CCSI_VERSION.yaml cinder-provider.yaml > cindercsi-$CCSI_VERSION.yaml
+  # correct ccsi image version - workaround for the https://github.com/kubernetes/cloud-provider-openstack/issues/2094
   sed -i "s|\(docker.io/k8scloudprovider/cinder-csi-plugin:\).*|\1$CCSI_VERSION|g" cindercsi-$CCSI_VERSION.yaml
   CCSI=cindercsi-$CCSI_VERSION.yaml
 else

--- a/terraform/files/bin/apply_cindercsi.sh
+++ b/terraform/files/bin/apply_cindercsi.sh
@@ -46,6 +46,7 @@ if test -n "$CCSI_VERSION"; then
   done
   # Note: We leave out the secret which we should already have
   cat cinder-csi-*-rbac-$CCSI_VERSION.yaml cinder-csi-*plugin-$CCSI_VERSION.yaml csi-cinder-driver-$CCSI_VERSION.yaml cinder-provider.yaml > cindercsi-$CCSI_VERSION.yaml
+  sed -i "s|\(docker.io/k8scloudprovider/cinder-csi-plugin:\).*|\1$CCSI_VERSION|g" cindercsi-$CCSI_VERSION.yaml
   CCSI=cindercsi-$CCSI_VERSION.yaml
 else
   CCSI=cinder.yaml

--- a/terraform/files/bin/apply_openstack_integration.sh
+++ b/terraform/files/bin/apply_openstack_integration.sh
@@ -30,6 +30,7 @@ if test -n "$OCCM_VERSION"; then
     if test ! -s $NAME; then
       curl -L https://github.com/kubernetes/cloud-provider-openstack/raw/$OCCM_VERSION/manifests/controller-manager/$name -o $NAME
       echo -e "\n---" >> $NAME
+      # correct occm image version - workaround for the https://github.com/kubernetes/cloud-provider-openstack/issues/2094
       sed -i "s|\(docker.io/k8scloudprovider/openstack-cloud-controller-manager:\).*|\1$OCCM_VERSION|g" $NAME
     fi
   done

--- a/terraform/files/bin/apply_openstack_integration.sh
+++ b/terraform/files/bin/apply_openstack_integration.sh
@@ -30,6 +30,7 @@ if test -n "$OCCM_VERSION"; then
     if test ! -s $NAME; then
       curl -L https://github.com/kubernetes/cloud-provider-openstack/raw/$OCCM_VERSION/manifests/controller-manager/$name -o $NAME
       echo -e "\n---" >> $NAME
+      sed -i "s|\(docker.io/k8scloudprovider/openstack-cloud-controller-manager:\).*|\1$OCCM_VERSION|g" $NAME
     fi
   done
   OCCM=openstack-cloud-controller-manager-ds-$OCCM_VERSION.yaml


### PR DESCRIPTION
Occm image version in the manifest differed from the specified version.

E.g occm version is 1.25.3 but image in the manifest is 'only' 1.25.0. See https://github.com/kubernetes/cloud-provider-openstack/blob/v1.25.3/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml
This also applies to ccsi.

Signed-off-by: Roman Hros <roman.hros@dnation.cloud>