### PR TITLE
Modify LB IP with dns suffix when the proxy protocol is used

### DIFF
--- a/terraform/files/template/cloud.conf.tmpl
+++ b/terraform/files/template/cloud.conf.tmpl
@@ -7,3 +7,4 @@ application-credential-secret="${appcredsecret}"
 [LoadBalancer]
 manage-security-groups=true
 use-octavia=true
+enable-ingress-hostname=true


### PR DESCRIPTION
Related to SovereignCloudStack/issues#250 and #184

See also https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip

Signed-off-by: Roman Hros <roman.hros@dnation.cloud>