### PR TITLE
Address #321: Finegrained repo location patching.

### DIFF
--- a/terraform/files/bin/create_cluster.sh
+++ b/terraform/files/bin/create_cluster.sh
@@ -77,10 +77,7 @@ if test "$CONTROL_PLANE_MACHINE_COUNT" -gt 0 &&  grep '^ *OPENSTACK_ANTI_AFFINIT
 fi
 
 # Patch registry location for k8s >= 1.21
-K8S_MAJMIN=$(grep '^KUBERNETES_VERSION:' $CCCFG | sed 's/^KUBERNETES_VERSION: v\([0-9]*\)\.\([0-9]*\).*$/\1\2/')
-if test "$K8S_MAJMIN" -ge 121 && grep 'k8s\.gcr\.io' ${CLUSTERAPI_TEMPLATE} >/dev/null 2>&1; then
-	sed -i 's/k8s\.gcr\.io/registry.k8s.io/g' ${CLUSTERAPI_TEMPLATE}
-fi
+fixup_k8sregistry.sh "$CCCFG" "${CLUSTERAPI_TEMPLATE}"
 
 cp -p "$CCCFG" $HOME/.cluster-api/clusterctl.yaml
 KCCCFG="--config $CCCFG"

--- a/terraform/files/bin/create_cluster.sh
+++ b/terraform/files/bin/create_cluster.sh
@@ -76,7 +76,7 @@ if test "$CONTROL_PLANE_MACHINE_COUNT" -gt 0 &&  grep '^ *OPENSTACK_ANTI_AFFINIT
 	fi
 fi
 
-# Patch registry location for k8s >= 1.21
+# Patch registry location for k8s (~newer than Nov 2022)
 fixup_k8sregistry.sh "$CCCFG" "${CLUSTERAPI_TEMPLATE}"
 
 cp -p "$CCCFG" $HOME/.cluster-api/clusterctl.yaml

--- a/terraform/files/bin/fixup_k8sregistry.sh
+++ b/terraform/files/bin/fixup_k8sregistry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # fixup_k8s_version.sh
 # Patch $2 (cluster-template.yaml) with fixed up k8s imageRepo if needed
-# This is to find old kube-proxy images on k8s.gcr.io and new ones on registry.k8s.io
+# This is to find old kube-proxy, coredns, ... images on k8s.gcr.io and new ones on registry.k8s.io
 # See https://github.com/kubernetes-sigs/cluster-api/blob/main/internal/util/kubeadm/kubeadm.go#L40
 # (c) Kurt Garloff, Roman Hros, 02/2023
 # SPDX-License-Identifier: Apache-2.0
@@ -9,7 +9,10 @@
 if test -z "$2"; then echo "ERROR: Need clusterctl.yaml cluster-template args" 1>&2; exit 1; fi
 K8SVER=$(grep '^KUBERNETES_VERSION:' "$1" | sed 's/^KUBERNETES_VERSION: v\([0-9.]*\)/\1/')
 K8SMINOR=${K8SVER#*.}
-K8SVER=${K8SVER%%.*}${K8SMINOR%%.*}$(printf %02i 0${K8SMINOR:3:99})
+K8SPATCH=${K8SMINOR#*.}
+if test "$K8SPATCH" = "$K8SMINOR"; then K8SPATCH=0; fi
+K8SMINOR=${K8SMINOR%%.*}
+K8SVER=${K8SVER%%.*}$(printf %02i ${K8SMINOR})$(printf %02i ${K8SPATCH})
 #echo $K8SVER
 if grep 'k8s\.gcr\.io' "$2" >/dev/null 2>&1; then
     if test "$K8SVER" -ge 12409 \

--- a/terraform/files/bin/fixup_k8sregistry.sh
+++ b/terraform/files/bin/fixup_k8sregistry.sh
@@ -9,8 +9,8 @@
 if test -z "$2"; then echo "ERROR: Need clusterctl.yaml cluster-template args" 1>&2; exit 1; fi
 K8SVER=$(grep '^KUBERNETES_VERSION:' "$1" | sed 's/^KUBERNETES_VERSION: v\([0-9.]*\)/\1/')
 K8SMINOR=${K8SVER#*.}
-K8SVER=${K8SVER%%.*}${K8SMINOR%%.*}$(printf %02i 0${K8SVER##*.})
-echo $K8SVER
+K8SVER=${K8SVER%%.*}${K8SMINOR%%.*}$(printf %02i 0${K8SMINOR:3:99})
+#echo $K8SVER
 if grep 'k8s\.gcr\.io' "$2" >/dev/null 2>&1; then
     if test "$K8SVER" -ge 12409 \
 	|| test "$K8SVER" -lt 12400 -a "$K8SVER" -ge 12315 \

--- a/terraform/files/bin/fixup_k8sregistry.sh
+++ b/terraform/files/bin/fixup_k8sregistry.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# fixup_k8s_version.sh
+# Patch $2 (cluster-template.yaml) with fixed up k8s imageRepo if needed
+# This is to find old kube-proxy images on k8s.gcr.io and new ones on registry.k8s.io
+# See https://github.com/kubernetes-sigs/cluster-api/blob/main/internal/util/kubeadm/kubeadm.go#L40
+# (c) Kurt Garloff, Roman Hros, 02/2023
+# SPDX-License-Identifier: Apache-2.0
+
+if test -z "$2"; then echo "ERROR: Need clusterctl.yaml cluster-template args" 1>&2; exit 1; fi
+K8SVER=$(grep '^KUBERNETES_VERSION:' "$1" | sed 's/^KUBERNETES_VERSION: v\([0-9.]*\)/\1/')
+K8SMINOR=${K8SVER#*.}
+K8SVER=${K8SVER%%.*}${K8SMINOR%%.*}$(printf %02i 0${K8SVER##*.})
+echo $K8SVER
+if grep 'k8s\.gcr\.io' "$2" >/dev/null 2>&1; then
+    if test "$K8SVER" -ge 12409 \
+	|| test "$K8SVER" -lt 12400 -a "$K8SVER" -ge 12315 \
+	|| test "$K8SVER" -lt 12300 -a "$K8SVER" -ge 12217; then
+	sed -i 's/k8s\.gcr\.io/registry.k8s.io/g' "$2"
+    fi
+fi


### PR DESCRIPTION
So we copy the capi knowledge of whether kube-proxy is at the old location (k8s.gcr.io) or at the new one (registry.k8s.io).
As the logic became somewhat involed, split it out into a separate script that can be tested more easily.

Signed-off-by: Kurt Garloff <kurt@garloff.de>