### PR TITLE
Fix needrestart configuration

### DIFF
--- a/terraform/files/bin/prepare_openstack.sh
+++ b/terraform/files/bin/prepare_openstack.sh
@@ -3,7 +3,6 @@
 export OS_CLOUD=$(yq eval '.OPENSTACK_CLOUD' ~/cluster-defaults/clusterctl.yaml)
 
 #install Openstack CLI
-export NEEDRESTART_SUSPEND=1	# Ubu 22.04 bug
 sudo apt install -y python3-openstackclient python3-octaviaclient
 # fix bug 1876317
 sudo patch -p2 -N -d /usr/lib/python3/dist-packages/keystoneauth1 < /tmp/fix-keystoneauth-plugins-unversioned.diff

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -59,7 +59,19 @@ write_files:
     owner: root:root
     path: /tmp/daemon.json
     permissions: '0644'
+  - content: |
+      $nrconf{kernelhints} = -1;
+      $nrconf{restart} = 'a';
+    owner: root:root
+    path: /tmp/needrestart.conf
+    permissions: '0644'
 runcmd:
+  # Note: Needrestart is part of the `apt-get upgrade` process from Ubuntu 22.04. By default, it is set to an
+  #   "interactive" mode which causes the interruption of scripts. The interactive mode is applied when the new kernel
+  #   version is available after the upgrade process and when upgraded services need to restart. A custom configuration
+  #   file overrides mentioned settings and ensures that kernel hints are printed only to stderr and services are
+  #   restarted automatically if needed.
+  - mv /tmp/needrestart.conf /etc/needrestart/conf.d/ || echo "Needrestart is not installed. Skipped."
   - echo nf_conntrack > /etc/modules-load.d/90-nf_conntrack.conf
   - modprobe nf_conntrack
   - echo net.netfilter.nf_conntrack_max=131072 > /etc/sysctl.d/90-conntrack_max.conf


### PR DESCRIPTION
`Needrestart` is part of the `apt-get upgrade` process in Ubuntu 22.04. By default, it is set to an "interactive" mode which causes the interruption of scripts. The interactive mode is applied when the new kernel version is available after the upgrade process or when upgraded services need to restart.

### Issue 

 Needrestart causes that after the new kernel is released and/or a new version of some upgraded service is released the needrestart daemon opens an interactive dialog  and interrupts scripts e.g. as follows: 

- A new kernel version is available
  ![Screenshot from 2023-02-20 14-34-19](https://user-images.githubusercontent.com/17620218/220313321-04fbfd27-44d9-4bbc-8a0e-6803bd5490a5.png)

- Services should be restarted
  ![image](https://user-images.githubusercontent.com/17620218/220313876-00baffc9-e726-4c10-9a74-987fd92d2afb.png)


### Steps to reproduce the issue 

Create the management host (`make create`) using TF variable: `image = "Ubuntu 22.04"` .

### PR
  
This PR adds a custom configuration file that overrides mentioned settings and ensures the following:
- Kernel hints are printed only to STDERR 
- Services are restarted automatically if needed

Notes:

- It is necessary to configure the needrestart daemon within the `cloud-config` script as the `cloud-config` script  
upgrades packages `package_upgrade: true`
- `NEEDRESTART_SUSPEND=1` variable has been removed as we have global settings in place now
- IMO automatic restart of services after an upgrade is a better approach than ignoring the needed restart of services by  suspending the  needrestart daemon
