### PR TITLE
Update to latest k8s and occm patch

### DIFF
--- a/terraform/files/bin/openstack-kube-versions.inc
+++ b/terraform/files/bin/openstack-kube-versions.inc
@@ -3,12 +3,12 @@
 # (c) Kurt Garloff <kurt@garloff.de>, 3/2022
 # SPDX-License-Identifier: Apache-2.0
 # Images from https://minio.services.osism.tech/openstack-k8s-capi-images
-k8s_versions=("v1.18.20" "v1.19.16" "v1.20.12" "v1.21.14" "v1.22.17" "v1.23.15" "v1.24.9" "v1.25.5" "v1.26.0")
+k8s_versions=("v1.18.20" "v1.19.16" "v1.20.15" "v1.21.14" "v1.22.17" "v1.23.16" "v1.24.10" "v1.25.6" "v1.26.1")
 # OCCM, CCM-RBAC, Cinder CSI, Cinder-Snapshot (TODO: Manila CSI)
-occm_versions=(""         ""       "v1.21.1"   "v1.21.1"  "v1.22.2"  "v1.23.4"  "v1.24.5" "v1.25.3" "v1.26.0") 
-#ccmr_versions=(""         ""        ""         ""         "v1.22.2"  "v1.23.4"  "v1.24.5" "v1.25.3" "v1.26.0")
-ccmr_versions=(""         ""        "v1.22.2"  "v1.22.2"  "v1.22.2"  "v1.23.4"  "v1.24.5" "v1.25.3" "v1.26.0")
-ccsi_versions=(""         ""        "v1.20.5"  "v1.21.1"  "v1.22.2"  "v1.23.4"  "v1.24.5" "v1.25.3" "v1.26.0")
+occm_versions=(""         ""       "v1.21.1"   "v1.21.1"  "v1.22.2"  "v1.23.4"  "v1.24.6" "v1.25.4" "v1.26.1")
+#ccmr_versions=(""         ""        ""         ""         "v1.22.2"  "v1.23.4"  "v1.24.6" "v1.25.4" "v1.26.1")
+ccmr_versions=(""         ""        "v1.22.2"  "v1.22.2"  "v1.22.2"  "v1.23.4"  "v1.24.6" "v1.25.4" "v1.26.1")
+ccsi_versions=(""         ""        "v1.20.5"  "v1.21.1"  "v1.22.2"  "v1.23.4"  "v1.24.6" "v1.25.4" "v1.26.1")
 min_snapshot_master="v1.21.0"
 # Versions that require a --allow-preview-versions flag
 techprev_versions=("v1.26" "v1.27" "v2")


### PR DESCRIPTION
This PR increases k8s versions to latest patch as well as occm patch versions as discussed in #322.