### PR TITLE
Fix cluster API load balancer lookup in the cleanup script

### DIFF
--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -111,15 +111,15 @@ fi
 echo "Deleting cluster $CLUSTER"
 # cleanup loadbalancers
 if test -n "$NOCASCADE"; then
-POOLS=$(resourcelist "loadbalancer pool" "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)")
+POOLS=$(resourcelist "loadbalancer pool" "\(clusterapi-.*-${CLUSTER}-kubeapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)")
 for POOL in $POOLS; do
 	#MEMBERS=$(resourcelist "loadbalancer member" clusterapi $POOL)
-	cleanup "loadbalancer member" "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)" $POOL
+	cleanup "loadbalancer member" "\(clusterapi-.*-${CLUSTER}-kubeapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)" $POOL
 done
 cleanup_list "loadbalancer pool" "" "" "$POOLS"
-cleanup "loadbalancer listener" "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)"
+cleanup "loadbalancer listener" "\(clusterapi-.*-${CLUSTER}-kubeapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)"
 fi
-LBS=$(resourcelist loadbalancer "\(clusterapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)" "" vip_address)
+LBS=$(resourcelist loadbalancer "\(clusterapi-.*-${CLUSTER}-kubeapi\|kube_service_${CLUSTER}_ingress-nginx_ingress-nginx-controller\)" "" vip_address)
 #cleanup_list "floating ip" 2 "" "$LBS"
 while read LB FIP; do
 	if test -z "$FIP"; then continue; fi


### PR DESCRIPTION
The cleanup script did not consider a cluster name when it looked for load balancers created by CAPI. 
This might cause the cleanup script wrongly removes all CAPI load balancers from the OpenStack project,
when e.g. two CAPI clusters (with different names) want to share one OpenStack project.

This PR adds a cluster name to the filter of CAPI load balancers.

Closes #344