### PR TITLE
Upgrade CAPI to v1.3.5 and CAPO to v0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,8 +440,8 @@ environment | clusterctl.yaml | provenance | default |  meaning
 `kind_flavor` | | SCS | `SCS-1V:4:20` | Flavor to be used for the k8s capi mgmt node
 `image` | | SCS | `Ubuntu 22.04` | Image to be deployed for the capi mgmt node
 `ssh_username` | | SCS | `ubuntu` | Name of the default user for the `image`
-`clusterapi_version` | | SCS | `1.2.6` | Version of the cluster-API incl. `clusterctl`
-`capi_openstack_version` | | SCS | `0.6.4` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
+`clusterapi_version` | | SCS | `1.3.5` | Version of the cluster-API incl. `clusterctl`
+`capi_openstack_version` | | SCS | `0.7.1` | Version of the cluster-api-provider-openstack (needs to fit the capi version)
 
 Parameters controlling both management node creation and cluster creation:
 

--- a/Release-Notes-R4-draft.md
+++ b/Release-Notes-R4-draft.md
@@ -19,7 +19,7 @@ R4 was released on 2024-03-22.
 
 ## Updated software
 
-### capi v1.. and openstack capi provider 0..
+### capi v1.3.5 and openstack capi provider 0.7.1
 
 [Kubernetes Cluster API Provider](https://cluster-api.sigs.k8s.io/)
 [OpenStack Provider for CAPI](https://cluster-api-openstack.sigs.k8s.io/)

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -7,8 +7,8 @@ external             = "<external_network_name>"
 dns_nameservers      = [ "DNS_IP1", "DNS_IP2" ]	  # defaults to [ "5.1.66.255", "185.150.99.255" ] (FF MUC)
 kind_flavor          = "<flavor>"                 # defaults to SCS-1V:4:20  (larger does not hurt)
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"
-clusterapi_version   = "<1.x.y>"		  # defaults to "1.2.6"
-capi_openstack_version = "<0.x.y>"		  # defaults to "0.6.4"
+clusterapi_version   = "<1.x.y>"		  # defaults to "1.3.5"
+capi_openstack_version = "<0.x.y>"		  # defaults to "0.7.1"
 image                = "<glance_image>"		  # defaults to "Ubuntu 22.04"
 # Settings for testcluster
 kubernetes_version   = "<v1.XX.XX>"		  # defaults to "v1.23.x"

--- a/terraform/files/bin/openstack-kube-versions.inc
+++ b/terraform/files/bin/openstack-kube-versions.inc
@@ -11,7 +11,7 @@ ccmr_versions=(""         ""        "v1.22.2"  "v1.22.2"  "v1.22.2"  "v1.23.4"  
 ccsi_versions=(""         ""        "v1.20.5"  "v1.21.1"  "v1.22.2"  "v1.23.4"  "v1.24.6" "v1.25.4" "v1.26.1")
 min_snapshot_master="v1.21.0"
 # Versions that require a --allow-preview-versions flag
-techprev_versions=("v1.26" "v1.27" "v2")
+techprev_versions=("v1.27" "v2")
 
 # Convert vxx.yy.zz to the number xxyyzz. Also works for z.y.z (0x0y0z).
 dotversion()

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -11,7 +11,7 @@ spec:
     serviceDomain: "cluster.local"
   infrastructureRef:
     #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
     kind: OpenStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -20,7 +20,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane
 ---
 #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -47,7 +47,7 @@ spec:
     infrastructureRef:
       kind: OpenStackMachineTemplate
       #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
       name: "${PREFIX}-${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}"
   kubeadmConfigSpec:
     initConfiguration:
@@ -134,7 +134,7 @@ spec:
   version: "${KUBERNETES_VERSION}"
 ---
 #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackMachineTemplate
 metadata:
   name: ${PREFIX}-${CLUSTER_NAME}-control-plane-${CONTROL_PLANE_MACHINE_GEN}
@@ -176,11 +176,11 @@ spec:
       infrastructureRef:
         name: "${PREFIX}-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}"
         #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
         kind: OpenStackMachineTemplate
 ---
 #apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackMachineTemplate
 metadata:
   name: ${PREFIX}-${CLUSTER_NAME}-md-0-${WORKER_MACHINE_GEN}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,13 +58,13 @@ variable "calico_version" {
 variable "clusterapi_version" {
   description = "desired version of cluster-api"
   type        = string
-  default     = "1.2.6"
+  default     = "1.3.5"
 }
 
 variable "capi_openstack_version" {
   description = "desired version of the OpenStack cluster-api provider"
   type        = string
-  default     = "0.6.4"
+  default     = "0.7.1"
 }
 
 variable "kubernetes_version" {


### PR DESCRIPTION
This PR updates the following:
- Cluster API provider (CAPI) version from v1.6.2 to v1.3.5
- OpenStack provider for CAPI (CAPO) version from v0.6.4 to v0.7.1
- CAPO API version in `cluster-template.yaml` from v1alpha5 to v1alpha6


Note1:
Tested with Ubuntu22.04 and Ubuntu20.04 

Note2: 
There are no further changes between CAPO  `v1alpha5` and `v1alpha6`:
```diff
$ diff <(curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/main/kustomize/v1alpha5/default/cluster-template.yaml) <(curl -s https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-openstack/main/kustomize/v1alpha6/default/cluster-template.yaml)
12c12
<     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
---
>     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
20c20
< apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
---
> apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
46c46
<       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
---
>       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
97c97
< apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
---
> apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
133c133
<         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
---
>         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
136c136
< apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
---
> apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
```

Closes #330 