### PR TITLE
Add prefix to security groups allow-ssh and allow-icmp

### DIFF
--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -174,7 +174,7 @@ if test "$FULL" == "1"; then
 	#cleanup router ${CAPIPRE}-
 	cleanup_list router "" "" "$RTR"
 	cleanup "security group" ${CAPIPRE}-mgmt
-	cleanup "security group" allow-
+	cleanup "security group" ${CAPIPRE}-allow-
 	cleanup keypair ${CAPIPRE}-keypair
 	cleanup "application credential" ${CAPIPRE}-appcred
 	#cleanup volume pvc-

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -150,8 +150,8 @@ spec:
         name: ${CLUSTER_NAME}-cloud-config
         kind: Secret
       securityGroups:
-        - name: allow-ssh
-        - name: allow-icmp
+        - name: ${PREFIX}-allow-ssh
+        - name: ${PREFIX}-allow-icmp
         - name: ${PREFIX}-${CLUSTER_NAME}-cilium
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -196,8 +196,8 @@ spec:
       image: ${OPENSTACK_IMAGE_NAME}
       sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
       securityGroups:
-        - name: allow-ssh
-        - name: allow-icmp
+        - name: ${PREFIX}-allow-ssh
+        - name: ${PREFIX}-allow-icmp
         - name: ${PREFIX}-${CLUSTER_NAME}-cilium
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/terraform/neutron.tf
+++ b/terraform/neutron.tf
@@ -1,7 +1,7 @@
 # generic security group allow ssh connection 
 # used for cluster-api-nodes
 resource "openstack_compute_secgroup_v2" "security_group_ssh" {
-  name        = "allow-ssh"
+  name        = "${var.prefix}-allow-ssh"
   description = "security group for ssh 22/tcp (managed by terraform)"
 
   rule {
@@ -15,7 +15,7 @@ resource "openstack_compute_secgroup_v2" "security_group_ssh" {
 # generic security group allow icmp connection
 # used for cluster-api-nodes
 resource "openstack_compute_secgroup_v2" "security_group_icmp" {
-  name        = "allow-icmp"
+  name        = "${var.prefix}-allow-icmp"
   description = "security group for ICMP"
 
   rule {


### PR DESCRIPTION
Security groups allow-ssh and allow-icmp are created by the terraform script and then referenced in the cluster template. In a special case when e.g. two management nodes and then two CAPI clusters (with different names) want to share one OpenStack project, the allow-ssh, and allow-icmp are created two times. These sec. groups have the same names but have different IDs. As the CAPI provider looks for sec. group by its name, not by ID, the cluster node could have the "doubled" sec. groups association. This is an unwanted behavior that may break e.g. cleanup process, where the terraform wants to remove sec. group used by another cluster.

This PR adds a "prefix" to the allow-ssh and allow-icmp sec. groups that distinguish their usage in a single OpenStack project.

Closes #343