### PR TITLE
Deploy snapshot controller to enable enable the volume snapshot feature

### DIFF
--- a/Release-Notes-R5.md
+++ b/Release-Notes-R5.md
@@ -1,0 +1,11 @@
+# Release Notes of SCS k8s-capi-provider for R5
+
+## New features
+
+### Storage snapshots
+The CSI driver deployed with SCS (in R4) did not have the needed snapshot-controller
+container ([#408](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/issues/408))
+deployed while it already did deploy the needed snapshot CRDs.
+The missing container has been added now ([#415](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/pull/415))
+and snapshot functionality is validated using the check-csi CNCF/sonobuoy test.
+

--- a/terraform/files/bin/apply_cindercsi.sh
+++ b/terraform/files/bin/apply_cindercsi.sh
@@ -29,6 +29,17 @@ if test -n "$SNAP_VERSION"; then
   done
   # FIXME: Should we ignore non-working snapshots?
   cat snapshot.storage.k8s.io_volumesnapshot* > cindercsi-snapshot-$SNAP_VERSION.yaml
+
+  # deploy snapshot controller
+  for name in rbac-snapshot-controller.yaml setup-snapshot-controller.yaml; do
+    NAME=${name%.yaml}-$SNAP_VERSION.yaml
+    if ! test -s $NAME; then
+      curl -L https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$SNAP_VERSION/deploy/kubernetes/snapshot-controller/$name -o $NAME
+      echo -e "\n---" >> $NAME
+    fi
+    cat $NAME >> cindercsi-snapshot-$SNAP_VERSION.yaml
+  done
+
   cp -p cindercsi-snapshot-$SNAP_VERSION.yaml ~/${CLUSTER_NAME}/deployed-manifests.d/cindercsi-snapshot.yaml
 else
   cp -p external-snapshot-crds.yaml ~/$CLUSTER_NAME/deployed-manifests.d/cindercsi-snapshot.yaml


### PR DESCRIPTION
See #408

Snapshots now can be created, e.g. following this [tutorial](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/features.md#volume-snapshots).