### PR TITLE
Update CAPI to v1.3.8 and CAPO to 0.7.3.

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -19,8 +19,8 @@ Parameters controlling the Cluster-API management server (capi management server
 | `kind_flavor`            |                 | SCS        | `SCS-1V-4-20`     | Flavor to be used for the k8s capi mgmt server                                |
 | `image`                  |                 | SCS        | `Ubuntu 22.04`    | Image to be deployed for the capi mgmt server                                 |
 | `ssh_username`           |                 | SCS        | `ubuntu`          | Name of the default user for the `image`                                      |
-| `clusterapi_version`     |                 | SCS        | `1.3.5`           | Version of the cluster-API incl. `clusterctl`                                 |
-| `capi_openstack_version` |                 | SCS        | `0.7.1`           | Version of the cluster-api-provider-openstack (needs to fit the CAPI version) |
+| `clusterapi_version`     |                 | SCS        | `1.3.8`           | Version of the cluster-API incl. `clusterctl`                                 |
+| `capi_openstack_version` |                 | SCS        | `0.7.3`           | Version of the cluster-api-provider-openstack (needs to fit the CAPI version) |
 | `cilium_binaries`        |                 | SCS        | `v0.13.1;v0.11.2` | Versions of the cilium and hubble CLI in the vA.B.C;vX.Y.Z format             |
 
 Parameters controlling both management server creation and cluster creation:

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -7,8 +7,8 @@ external             = "<external_network_name>"
 dns_nameservers      = [ "DNS_IP1", "DNS_IP2" ]	  # defaults to [ "5.1.66.255", "185.150.99.255" ] (FF MUC)
 kind_flavor          = "<flavor>"                 # defaults to SCS-1V-4-20  (larger does not hurt)
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"
-clusterapi_version   = "<1.x.y>"		  # defaults to "1.3.5"
-capi_openstack_version = "<0.x.y>"		  # defaults to "0.7.1"
+clusterapi_version   = "<1.x.y>"		  # defaults to "1.3.8"
+capi_openstack_version = "<0.x.y>"		  # defaults to "0.7.3"
 image                = "<glance_image>"		  # defaults to "Ubuntu 22.04"
 cilium_binaries      = "<v0.aa.bb;v0.xx.yy>"  # defaults to "v0.13.1;v0.11.2"
 # Settings for testcluster

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,13 +58,13 @@ variable "calico_version" {
 variable "clusterapi_version" {
   description = "desired version of cluster-api"
   type        = string
-  default     = "1.3.5"
+  default     = "1.3.8"
 }
 
 variable "capi_openstack_version" {
   description = "desired version of the OpenStack cluster-api provider"
   type        = string
-  default     = "0.7.1"
+  default     = "0.7.3"
 }
 
 variable "kubernetes_version" {


### PR DESCRIPTION
These are bugfix only changes.
CAPI-v1.3.8:
    clusterctl: Return error on infra cluster and control plane discovery (#8610)
    e2e: Adjust machinepool helper e2e timeout (#8755)
    e2e: test/e2e check for machines being ready after provisioning on Runtime SDK test (#8647)
    e2e: test/framework fix docker pod log collector (#8644)
    KCP: Allow machine rollout if cert reconcile fails (#8738)
    KCP: Prevent KCP to create many private keys for each reconcile (#8626)
    CAPD: change the haproxy entrypoint to prevent getting stopped immediately after start (#8741)
    CAPD: Delegate CAPD port selection to the container runtime (#8654)
CAPI-v1.3.7:
    clusterctl: Use local kustomize version in create-local-repository.py (#8436)
    Dependency: Update kindnetd and kindest/haproxy (#8471)
CAPI-v1.3.6:
    API: Implements Getter interface for IPAddressClaim object (#8380)
    test: Make it possible to run envtest-based integration tests from vscode (#8212)

CAPO-v0.7.3:
    Always filter cluster subnets by cluster network ID (#1573)
CAPO-v0.7.2:
    Backport Octavia OVN provider support to release-0.7 (#1529)
    Infer port network from subnet (#1526)