### PR TITLE
Update kind to 0.18.0

### DIFF
--- a/Release-Notes-R5.md
+++ b/Release-Notes-R5.md
@@ -1,5 +1,9 @@
 # Release Notes of SCS k8s-capi-provider for R5
 
+## Updated software
+
+### kind 0.18.0
+
 ## New features
 
 ### Storage snapshots

--- a/terraform/files/bin/install_kind.sh
+++ b/terraform/files/bin/install_kind.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-KIND_VERSION=0.17.0
+KIND_VERSION=0.18.0
 sudo wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
 sudo chmod +x /usr/local/bin/kind
 kind create cluster


### PR DESCRIPTION
K8s version is now 1.26.3.

We cannot upgrade to 0.19 or 0.20 for now because capi is still [v1.3.x](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/pull/427) and for kubernetes 1.27 capi [v1.4 is required](https://cluster-api.sigs.k8s.io/reference/versions.html).