### PR TITLE
Fix configure_containerd.sh script idempotency

### DIFF
--- a/terraform/files/bin/configure_containerd.sh
+++ b/terraform/files/bin/configure_containerd.sh
@@ -62,14 +62,14 @@ for path in "${paths[@]}"; do
       # see related YQ docs: https://mikefarah.gitbook.io/yq/operators/alternative-default-value#update-or-create-entity-does-not-exist
       file_cp_exist=$(yq 'select(.kind == "KubeadmControlPlane").spec.kubeadmConfigSpec | (.files // (.files = []))[] | select(.path == env(destination_path) + env(file_name))' "$1")
       if test -z "$file_cp_exist"; then
-        echo "Adding $file_name to the in KubeadmControlPlane files"
+        echo "Adding $file_name to the KubeadmControlPlane files"
         yq 'select(.kind == "KubeadmControlPlane").spec.kubeadmConfigSpec.files += [load("file_tmp")]' -i "$1"
       else
         echo "$file_name is already defined in KubeadmControlPlane files"
       fi
       file_ct_exist=$(yq 'select(.kind == "KubeadmConfigTemplate").spec.template.spec | (.files // (.files = []))[] | select(.path == env(destination_path) + env(file_name))' "$1")
       if test -z "$file_ct_exist"; then
-        echo "Adding $file_name to the in KubeadmConfigTemplate files"
+        echo "Adding $file_name to the KubeadmConfigTemplate files"
         yq 'select(.kind == "KubeadmConfigTemplate").spec.template.spec.files += [load("file_tmp")]' -i "$1"
       else
         echo "$file_name is already defined in KubeadmConfigTemplate files"

--- a/terraform/files/bin/configure_containerd.sh
+++ b/terraform/files/bin/configure_containerd.sh
@@ -57,10 +57,23 @@ for path in "${paths[@]}"; do
         .permissions = "0644" |
         .content = loadstr(env(file))
         ' > file_tmp
-
-      yq 'select(.kind == "KubeadmControlPlane").spec.kubeadmConfigSpec.files += [load("file_tmp")]' -i "$1"
-      yq 'select(.kind == "KubeadmConfigTemplate").spec.template.spec.files += [load("file_tmp")]' -i "$1"
-
+      # Evaluate whether the file is already present in the cluster-template.yaml.
+      # YAML key `files` is not mandatory therefore it should be added as an empty array to ensure that the whole evaluation will work as expected,
+      # see related YQ docs: https://mikefarah.gitbook.io/yq/operators/alternative-default-value#update-or-create-entity-does-not-exist
+      file_cp_exist=$(yq 'select(.kind == "KubeadmControlPlane").spec.kubeadmConfigSpec | (.files // (.files = []))[] | select(.path == env(destination_path) + env(file_name))' "$1")
+      if test -z "$file_cp_exist"; then
+        echo "Adding $file_name to the in KubeadmControlPlane files"
+        yq 'select(.kind == "KubeadmControlPlane").spec.kubeadmConfigSpec.files += [load("file_tmp")]' -i "$1"
+      else
+        echo "$file_name is already defined in KubeadmControlPlane files"
+      fi
+      file_ct_exist=$(yq 'select(.kind == "KubeadmConfigTemplate").spec.template.spec | (.files // (.files = []))[] | select(.path == env(destination_path) + env(file_name))' "$1")
+      if test -z "$file_ct_exist"; then
+        echo "Adding $file_name to the in KubeadmConfigTemplate files"
+        yq 'select(.kind == "KubeadmConfigTemplate").spec.template.spec.files += [load("file_tmp")]' -i "$1"
+      else
+        echo "$file_name is already defined in KubeadmConfigTemplate files"
+      fi
       rm file_tmp
     fi
   done


### PR DESCRIPTION
Script configure_containerd.sh did not evaluate whether the containerd file is already present in the cluster-template.yaml. Hence, the file could be added on each script execution.

This commit adds a check which evaluates whether the containerd file is already present in the cluster-template.yaml. This makes configure_containerd.sh idempotent.

Closes #471