### PR TITLE
Gets variable username from <env>.tfvars

### DIFF
--- a/doc/make-reference.md
+++ b/doc/make-reference.md
@@ -40,8 +40,7 @@ This will get the kubeconfig of the testcluster and store it in the file ``testc
 
 ``make ssh``
 
-This will ssh into the management server. You may need to set the ``USERNAME`` variable to the username you set
-in your ``environment-<yourcloud>.tfvars`` file. The default in the environment file is ``ubuntu``.
+This will ssh into the management server, using the username that was set in your ``environment-<yourcloud>.tfvars``file. The default in the environment file is ``ubuntu``.
 
 > Note: there is also an alias to this `make login`
 

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -8,7 +8,6 @@ SHELL=/bin/bash
 SED ?= sed
 #ENVIRONMENT = gx-bc
 OPENSTACK ?= openstack
-USERNAME ?= ubuntu
 CONSOLE = capi-mgmtcluster
 #TESTCLUSTER ?= testcluster
 
@@ -19,6 +18,7 @@ ifeq ($(NEED_OSCLOUD),1)
 else
   ENVIRONMENT ?= $(OS_CLOUD)
 endif
+USERNAME=$(shell ( grep '^ssh_username' environments/environment-$(ENVIRONMENT).tfvars || echo ubuntu ) | $(SED) 's@^ssh_username[^=]*= *"*\([^"]*\).*$$@\1@' )
 
 # if enabled, use s3 for remote terraform state
 ifneq (,$(wildcard ./minio.env))


### PR DESCRIPTION
Signed-off-by: Malte Münch <muench@b1-systems.de>

Currently if $USERNAME is set in the environment that calls make, this value is used instead of 
the value supplied in environments/environment-<env>.tfvars. I am unsure whether this is intended
or unintended. However with this version the value in the *.tfvars is used to connect in the various
make targets
