### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/check-terraform-syntax.yml
+++ b/.github/workflows/check-terraform-syntax.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: create config
         run: cp clouds.yaml.sample clouds.yaml
         working-directory: ./terraform

--- a/.github/workflows/check-yaml-syntax.yml
+++ b/.github/workflows/check-yaml-syntax.yml
@@ -17,8 +17,8 @@ jobs:
   check-yaml-syntax:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - run: pip3 install yamllint


### PR DESCRIPTION
It resolves warning:
`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/`