### PR TITLE
Ignores .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ secure.yaml
 terraform.tfstate.d
 terraform.tfstate*
 .terraform.lock.hcl
+.envrc


### PR DESCRIPTION
The repo relies on OS_CLOUD to be set to choose the cloud-provider and the environment to work on.
I use [direnv](https://direnv.net/) to automatically set my cloud provider when entering the `terraform`
folder. This PR extends the `.gitignore` to ignore the `.envrc` file (direnvs per directory config). So that
no other users are bothered with my default environment being set when using this repo.

Signed-off-by: Malte Münch <muench@b1-systems.de>
