### PR TITLE
Fix delete_cluster.sh and others to handle per cluster ns on os #492

### DIFF
--- a/terraform/files/bin/add_cluster-network.sh
+++ b/terraform/files/bin/add_cluster-network.sh
@@ -25,7 +25,8 @@ findnewnic()
 MGMT="$PREFIX-mgmtcluster"
 # FIXME: We already know the name ($PREFIX-mgmtcluster)
 #MGMT=$(openstack server list --name "$PREFIX-mgmtcluster" -f value -c Name)
-openstack server add network $MGMT k8s-clusterapi-cluster-default-$CLUSTER_NAME || exit
+NETWORK=$(openstack network list -f value -c Name | grep "k8s-clusterapi-cluster-\(default-${CLUSTER_NAME}\|${CLUSTER_NAME}-${CLUSTER_NAME}\)")
+openstack server add network $MGMT $NETWORK || exit
 WAIT=0
 while test $WAIT -lt 30; do
 	findnewnic

--- a/terraform/files/bin/enable-cilium-sg-kube.sh
+++ b/terraform/files/bin/enable-cilium-sg-kube.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 . ~/bin/cccfg.inc
-SGS=$(openstack security group list -f value -c ID -c Name | grep "k8s-cluster-default-${CLUSTER_NAME}-secgroup-")
+SGS=$(openstack security group list -f value -c ID -c Name | grep "k8s-cluster-\(default-${CLUSTER_NAME}\|${CLUSTER_NAME}-${CLUSTER_NAME}\)-secgroup-")
 SG_WORKER=$(echo "$SGS" | grep worker | cut -d " " -f1)
 SG_CONTROL=$(echo "$SGS" | grep controlplane | cut -d " " -f1)
 #rm -f enable-cilium-control.yaml enable-cilium-worker.yaml

--- a/terraform/files/bin/mng_cluster_ns.inc
+++ b/terraform/files/bin/mng_cluster_ns.inc
@@ -1,6 +1,11 @@
 export KUBECONFIG=$HOME/.kube/config
 kubectl config use-context kind-kind
 
+if [ -z "$CLUSTER_NAME" ]; then
+  echo "CLUSTER_NAME is not set. Exiting."
+  exit 1
+fi
+
 # Check if the cluster already exists
 existing_cluster=$(kubectl get cluster --all-namespaces -o jsonpath='{range .items[?(@.metadata.name == "'$CLUSTER_NAME'")]}{.metadata.namespace}{end}')
 
@@ -8,12 +13,14 @@ if [ -n "$existing_cluster" ]; then
   echo "> Cluster $CLUSTER_NAME already exists in namespace $existing_cluster"
   echo "> Changing namespace to $existing_cluster"
   kubectl config set-context --current --namespace=$existing_cluster
+  export CLUSTER_NAMESPACE=$existing_cluster
 else
   if [ -z "$CREATE_NEW_NAMESPACE" ] || [ "$CREATE_NEW_NAMESPACE" = true ]; then
     echo "> Cluster $CLUSTER_NAME does not exist. Creating a new cluster namespace..."
     kubectl create namespace $CLUSTER_NAME
     kubectl config set-context --current --namespace=$CLUSTER_NAME
     echo "> Namespace changed to $CLUSTER_NAME"
+    export CLUSTER_NAMESPACE=$CLUSTER_NAME
   else
     echo "> Cluster $CLUSTER_NAME does not exist, and new namespace creation is disabled."
   fi

--- a/terraform/files/bin/remove_cluster-network.sh
+++ b/terraform/files/bin/remove_cluster-network.sh
@@ -3,16 +3,28 @@ export KUBECONFIG=~/.kube/config
 . ~/.capi-settings
 . ~/bin/cccfg.inc
 
+NET_NAME=$(openstack network list -f value -c Name | grep "k8s-clusterapi-cluster-\(default-${CLUSTER_NAME}\|${CLUSTER_NAME}-${CLUSTER_NAME}\)")
+
 # Determine mgmtserver networks
 MGMT="$PREFIX-mgmtcluster"
 MGMTNET=$(openstack server list --name "$MGMT" -f value -c Networks)
-NET=$(echo "$MGMTNET" | grep "k8s-clusterapi-cluster-default-$CLUSTER_NAME=" | sed "s/.*k8s-clusterapi-cluster-default-$CLUSTER_NAME=\([0-9a-f:\.]*\).*\$/\1/")
-# New format
-if test -z "$NET"; then NET=$(echo "$MGMTNET" | grep "'k8s-clusterapi-cluster-default-$CLUSTER_NAME':" | sed "s/.*'k8s-clusterapi-cluster-default-$CLUSTER_NAME':[^']*'\([0-9a-f:\.]*\)'.*\$/\1/"); fi
-if test -z "$NET"; then echo "No network to remove ..."; exit 1; fi
+if [[ $NET_NAME == "k8s-clusterapi-cluster-default-"* ]]; then
+  # Old format of network name based on cluster in default namespace
+  NET=$(echo "$MGMTNET" | grep "k8s-clusterapi-cluster-default-$CLUSTER_NAME=" | sed "s/.*k8s-clusterapi-cluster-default-$CLUSTER_NAME=\([0-9a-f:\.]*\).*\$/\1/")
+  # New format
+  if test -z "$NET"; then NET=$(echo "$MGMTNET" | grep "'k8s-clusterapi-cluster-default-$CLUSTER_NAME':" | sed "s/.*'k8s-clusterapi-cluster-default-$CLUSTER_NAME':[^']*'\([0-9a-f:\.]*\)'.*\$/\1/"); fi
+else
+  # New format of network name based on cluster in cluster with namespace name as cluster name
+  NET=$(echo "$MGMTNET" | grep "k8s-clusterapi-cluster-$CLUSTER_NAME-$CLUSTER_NAME=" | sed "s/.*k8s-clusterapi-cluster-$CLUSTER_NAME-$CLUSTER_NAME=\([0-9a-f:\.]*\).*\$/\1/")
+  # New format
+  if test -z "$NET"; then NET=$(echo "$MGMTNET" | grep "'k8s-clusterapi-cluster-$CLUSTER_NAME-$CLUSTER_NAME':" | sed "s/.*'k8s-clusterapi-cluster-$CLUSTER_NAME-$CLUSTER_NAME':[^']*'\([0-9a-f:\.]*\)'.*\$/\1/"); fi
+fi
+if test -z "$NET"; then
+  echo "No network to remove ..."
+  exit 1
+fi
 NIC=$(ip addr | grep -B4 "inet $NET/" | grep '^[0-9]' | sed 's/^[0-9]*: \([^: ]*\): .*$/\1/')
 
 #sudo ip link set dev ens8 down
 echo "Removing NIC $NIC $NET ..."
-openstack server remove network $MGMT k8s-clusterapi-cluster-default-$CLUSTER_NAME || exit
-
+openstack server remove network $MGMT $NET_NAME || exit


### PR DESCRIPTION
CAPI generates OpenStack resource names based on the NS the cluster is in. 

This PR so far handles only scripts on the management node. Either I or @garloff will address this issue in full clean as well.