### PR TITLE
Ca rotation

### DIFF
--- a/doc/usage/custom-ca.md
+++ b/doc/usage/custom-ca.md
@@ -27,19 +27,47 @@ Here the file `ca-bundle.pem` contains custom root CA and potentially intermedia
 
 Steps of what happens with the custom cacert in k8s-cluster-api-provider:
 1. `cacert` setting is provided inside clouds.yaml
-2. Cacert file referenced by `cacert` key (1.) is copied to the management server by Terraform
-3. During the management server bootstrap process
-   cacert is injected to the *~/cluster-defaults/cluster-template.yaml* to
-   *KubeadmControlPlane* and *KubeadmConfigTemplate* files, so it will be later
-   copied to the workload cluster (control plane and worker nodes) provisioned by CAPO
+2. Cacert file referenced by `cacert` key (1.) is copied to the management server
+   directory `~/cluster-defaults/${cloud_provider}-cacert` by Terraform
+3. During the management server bootstrap process cacert is injected to
+   the *~/cluster-defaults/cluster-template.yaml* to *KubeadmControlPlane* and *KubeadmConfigTemplate* files
+   as file with cacert content from already defined secret *${CLUSTER_NAME}-cloud-config* and will be later
+   templated and copied to the workload cluster (control plane and worker nodes) provisioned by CAPO, e.g.:
+   ```yaml
+   files:
+   - contentFrom:
+       secret:
+         key: cacert
+         name: ${CLUSTER_NAME}-cloud-config
+     owner: root:root
+     path: /etc/ssl/certs/devstack-cacert
+     permissions: "0644"
+   ```
 4. When the creation of the workload cluster starts, *~/cluster-defaults/cluster-template.yaml*
    is copied into workload cluster directory (*~/$CLUSTER_NAME/*)
 5. Then the cacert file content is base64 encoded and saved in OPENSTACK_CLOUD_CACERT_B64 variable
    inside *~/$CLUSTER_NAME/clusterctl.yaml*, so it can be used during
    the workload cluster templating
 6. Later, when the workload cluster templates are applied to the management cluster,
-   secret with base64 encoded cacert is created and used by CAPO
+   secret *${CLUSTER_NAME}-cloud-config* with base64 encoded cacert is created and used by CAPO
 7. CAPO will create workload cluster (thanks to steps 5. and 6.) and cacert is
-   transferred to the control plane and worker nodes (thanks to steps 3. and 4.).
+   transferred to the control plane and worker nodes (thanks to steps 3. and 4.)
 8. OCCM and CCSI pods mount cacert via hostPath volume
    and use it for e.g. creating load balancers or volumes
+
+## Rotation
+
+When the custom CA expires or otherwise changes it needs to be rotated.
+CAPO uses the custom CA certificate in the management cluster for creating the infrastructure
+for the workload clusters and in the workload clusters by OCCM and CCSI for e.g. creating load balancers or volumes.
+In both cases, cacert is provided via secret *${CLUSTER_NAME}-cloud-config* and needs to be updated.
+
+There are 3 steps in this rotation process:
+1. Replace custom CA certificate in `~/cluster-defaults/${cloud_provider}-cacert`
+2. Increase generation counters `CONTROL_PLANE_MACHINE_GEN` and `WORKER_MACHINE_GEN` in `~/$CLUSTER_NAME/clusterctl.yaml`
+3. Run `create_cluster.sh $CLUSTER_NAME` and wait for the rolling update of your workload cluster
+
+> Steps 2 and 3 need to be done per workload cluster.
+
+> When step 2 is omitted, only cacert secret in the management cluster is updated and no rolling update of
+> the workload cluster in step 3 is started and existing nodes remain with the old certificate.

--- a/doc/usage/custom-ca.md
+++ b/doc/usage/custom-ca.md
@@ -63,9 +63,13 @@ for the workload clusters and in the workload clusters by OCCM and CCSI for e.g.
 In both cases, cacert is provided via secret *${CLUSTER_NAME}-cloud-config* and needs to be updated.
 
 There are 3 steps in this rotation process:
-1. Replace custom CA certificate in `~/cluster-defaults/${cloud_provider}-cacert`
+1. Replace/append custom CA certificate in `~/cluster-defaults/${cloud_provider}-cacert`
 2. Increase generation counters `CONTROL_PLANE_MACHINE_GEN` and `WORKER_MACHINE_GEN` in `~/$CLUSTER_NAME/clusterctl.yaml`
 3. Run `create_cluster.sh $CLUSTER_NAME` and wait for the rolling update of your workload cluster
+
+> In step 1, appending can be useful for avoiding downtime of your services.
+> Your cacert file will contain two CA certificates - old and new.
+> This should help with a smooth transition to a new certificate and later, the old one can be removed.
 
 > Steps 2 and 3 need to be done per workload cluster.
 

--- a/doc/usage/custom-ca.md
+++ b/doc/usage/custom-ca.md
@@ -43,8 +43,8 @@ Steps of what happens with the custom cacert in k8s-cluster-api-provider:
      path: /etc/ssl/certs/devstack-cacert
      permissions: "0644"
    ```
-4. When the creation of the workload cluster starts, *~/cluster-defaults/cluster-template.yaml*
-   is copied into workload cluster directory (*~/$CLUSTER_NAME/*)
+4. When the creation of the workload cluster (*create_cluster.sh*) starts,
+   *~/cluster-defaults/cluster-template.yaml* is copied into workload cluster directory (*~/$CLUSTER_NAME/*)
 5. Then the cacert file content is base64 encoded and saved in OPENSTACK_CLOUD_CACERT_B64 variable
    inside *~/$CLUSTER_NAME/clusterctl.yaml*, so it can be used during
    the workload cluster templating

--- a/terraform/files/bin/create_appcred.sh
+++ b/terraform/files/bin/create_appcred.sh
@@ -51,8 +51,8 @@ if test -z "$APPCRED_ID"; then
     interface: public
     identity_api_version: 3
     region_name: $REGION
-    auth_type: "v3applicationcredential"
     cacert: $CACERT
+    auth_type: "v3applicationcredential"
     auth:
       auth_url: $AUTH_URL
       #project_id: $APPCRED_PRJ

--- a/terraform/files/bin/inject_custom_ca.sh
+++ b/terraform/files/bin/inject_custom_ca.sh
@@ -1,26 +1,24 @@
 #!/usr/bin/env bash
-# ./inject_custom_ca.sh cluster-template.yaml CACERT CADEST
+# ./inject_custom_ca.sh cluster-template.yaml CADEST
 #
-# Script injects $2 (CACERT) into $1 (cluster-template.yaml).
-# CACERT will be injected to k8s nodes on $3 (CADEST) path.
+# Script injects cacert (file with content from secret ${CLUSTER_NAME}-cloud-config) into $1 (cluster-template.yaml).
+# Secret ${CLUSTER_NAME}-cloud-config contains key cacert with OPENSTACK_CLOUD_CACERT_B64 variable.
+# Cacert will be templated later and injected to k8s nodes on $2 (CADEST) path.
 # Inspiration taken from configure_containerd.sh
 #
 # (c) Roman Hros, 07/2023
 # SPDX-License-Identifier: Apache-2.0
 
 if test -z "$1"; then echo "ERROR: Need cluster-template.yaml arg" 1>&2; exit 1; fi
-if test -z "$2"; then echo "ERROR: Need CACERT arg" 1>&2; exit 1; fi
-if test -z "$3"; then echo "ERROR: Need CADEST arg" 1>&2; exit 1; fi
+if test -z "$2"; then echo "ERROR: Need CADEST arg" 1>&2; exit 1; fi
 
-export CA_FILE="$2"
-export CA_DEST="$3"
+export CA_DEST="$2"
 
 yq --null-input '
   .path = env(CA_DEST) |
   .owner = "root:root" |
   .permissions = "0644" |
-  .encoding = "base64" |
-  .content = (loadstr(env(CA_FILE)) | @base64)
+  .contentFrom = {"secret": {"key": "cacert", "name": "${CLUSTER_NAME}-cloud-config"}}
   ' > file_tmp
 
 yq 'select(.kind == "KubeadmControlPlane").spec.kubeadmConfigSpec.files += [load("file_tmp")]' -i "$1"

--- a/terraform/files/bin/prepare_openstack.sh
+++ b/terraform/files/bin/prepare_openstack.sh
@@ -23,5 +23,5 @@ if test "$CACERT" != "null"; then
   CADEST="/etc/ssl/certs/$(basename "$CACERT")" # path for OCCM
   echo "Set ca-file to $CADEST for $OS_CLOUD"
   sed -i "/^application.credential.secret/aca-file=$CADEST" ~/cluster-defaults/cloud.conf
-  inject_custom_ca.sh ~/cluster-defaults/cluster-template.yaml "$CACERT" "$CADEST"
+  inject_custom_ca.sh ~/cluster-defaults/cluster-template.yaml "$CADEST"
 fi


### PR DESCRIPTION
PR #460 added support for OpenStack custom CA certificate.
This PR complement it with easily manageable cacert which is already defined in secret *${CLUSTER_NAME}-cloud-config* so we have only one source of truth. Also, documentation about rotation is created.

Fixes #488