### PR TITLE
Require terraform version < 1.6.0

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ provider "openstack" {
 }
 
 terraform {
-  required_version = ">= 1.4.6"
+  required_version = ">= 1.4.6, < 1.6.0"
 
   required_providers {
     openstack = {


### PR DESCRIPTION
Protect users from accidentially using unfree BSL licensed code
Users can still manually update this version constraint if they want