### PR TITLE
Enhance make create to use actual commit for checkout #522

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -43,6 +43,9 @@ PREFIX:=$(shell (grep '^prefix *=' environments/environment-${ENVIRONMENT}.tfvar
 MGMTCLUSTERNAME:=$(shell ($(OPENSTACK) server list --name "$(PREFIX)-mgmtcluster" -c Name -f value))
 
 GITBRANCH=$(shell git branch | grep '^*' | $(SED) 's/^* //')
+# Specify a branch, tag or commit to checkout on the mgmtcluster
+GITREFERENCE=$(shell git rev-parse HEAD)
+# GITREFERENCE=$GITBRANCH
 GITREPO=$(shell git config --get remote.origin.url | sed 's%git@\([^:]*\):%https://\1/%')
 
 init:	mycloud
@@ -59,7 +62,7 @@ state-push: init
 	@terraform state push $(STATE)
 
 dry-run: init
-	terraform plan -var-file="environments/environment-$(ENVIRONMENT).tfvars" -var "git_branch=$(GITBRANCH)" $(PARAMS)
+	terraform plan -var-file="environments/environment-$(ENVIRONMENT).tfvars" -var "git_reference=$(GITREFERENCE)" $(PARAMS)
 
 mycloud: environments/environment-$(ENVIRONMENT).tfvars
 	@if [ -f "clouds.yaml" ]; then \
@@ -74,7 +77,11 @@ mycloud: environments/environment-$(ENVIRONMENT).tfvars
     fi
 
 gitchk:
-	@git diff -r origin/$(GITBRANCH) > git.diff
+	@if [ "$(GITREFERENCE)" != "$(GITBRANCH)" ]; then \
+		git diff -r $(GITREFERENCE) -- :/ ':(exclude,top)terraform/environments' > git.diff ; \
+	else \
+  		git diff -r origin/$(GITBRANCH) -- :/ ':(exclude,top)terraform/environments' > git.diff ; \
+	fi
 	@if test -s git.diff; then echo "WARN: Local changes won't be used on mgmtcluster. Commit and push them"; cat git.diff; fi
 
 create: init
@@ -82,7 +89,7 @@ create: init
 		echo "Management cluster with prefix $(PREFIX) already exists. This is not supported due to unexpected side-effects." && exit 1; \
 	else \
 		touch .deploy.$(ENVIRONMENT); \
-		terraform apply -auto-approve -var-file="environments/environment-$(ENVIRONMENT).tfvars" -var "git_branch=$(GITBRANCH)" -var "git_repo=$(GITREPO)"; \
+		terraform apply -auto-approve -var-file="environments/environment-$(ENVIRONMENT).tfvars" -var "git_reference=$(GITREFERENCE)" -var "git_repo=$(GITREPO)"; \
 	fi
 
 show: init

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -355,7 +355,7 @@ resource "terraform_data" "mgmtcluster_bootstrap_files" {
   # FIXME: We should get the branch (and warnings for unpushed changes from the Makefile)
   provisioner "remote-exec" {
     inline = [
-      "/tmp/get_k8s_git.sh ${var.git_repo} ${var.git_branch}",
+      "/tmp/get_k8s_git.sh ${var.git_repo} ${var.git_reference}",
       "/home/${var.ssh_username}/bin/bootstrap.sh"
     ]
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -195,8 +195,8 @@ variable "etcd_unsafe_fs" {
   default     = false
 }
 
-variable "git_branch" {
-  description = "k8s-cluster-api-provider git branch to be checked out on mgmtserver"
+variable "git_reference" {
+  description = "k8s-cluster-api-provider git reference to be checked out on mgmtserver"
   type        = string
   default     = "main"
 }


### PR DESCRIPTION
Now, when creating a new cluster, the exact commit as is active on the user's computer will be present on the cluster.