### PR TITLE
Feat/remove att volumes

### DIFF
--- a/doc/make-reference.md
+++ b/doc/make-reference.md
@@ -85,11 +85,15 @@ unfortunately, some error in the deployment may result in resources left around.
 
 ### Make fullclean
 
-``make fullclean`` uses a custom script (using the openstack CLI) to clean up everything
-while trying to not hit any resources not created by the CAPI or terraform.
+``make fullclean`` uses a custom script `cleanup/cleanup.sh` (using the openstack CLI) to clean up
+everything while trying to not hit any resources not created by the CAPI or terraform for
+clusters from this management host.
 It is the recommended way for doing cleanups if ``make clean`` fails. Watch out for leftover
 floating IP addresses and persistent volumes, as these can not be easily traced back to the
-Cluster API created resources and may thus be left.
+Cluster API created resources and may thus be left. There is also a ``make forceclean`` variant
+that hits unused floating IPs and all persistent volumes -- this is risky as there is no good
+way to tell which PVCs belong to us unless we find them attached to cluster nodes in which
+case we don't need the force options.
 
 ### Make purge
 

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -104,6 +104,12 @@ fullclean:
 	@if test -e ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); then source ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); ssh-keygen -R $$MGMTCLUSTER_ADDRESS -f ~/.ssh/known_hosts; rm -f .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); fi
 	$(MAKE) clean
 
+forceclean:
+	prefix=$$(grep '^prefix *=' environments/environment-${ENVIRONMENT}.tfvars | $(SED) -e 's/^[^=]*= *//' -e 's/"//g'); \
+	./cleanup/cleanup.sh --verbose --full --force-fip --force-pvc
+	@if test -e ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); then source ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); ssh-keygen -R $$MGMTCLUSTER_ADDRESS -f ~/.ssh/known_hosts; rm -f .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); fi
+	$(MAKE) clean
+
 purge:
 	@echo "Warning, going to delete ALL resources in $(ENVIRONMENT), even those that have not been created by the testbed. The SSH-Key capi-keypair will be removed for all projects."
 	@read -p "Continue? (y/n) " -r; \

--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -206,7 +206,8 @@ done < <(echo "$LBS")
 SRV=$(resourcelist server $CAPIPRE-$CLUSTER)
 SRVVOL=$(server_vols $SRV)
 if test -n "$DEBUG"; then echo "### Attached volumes to "${SRV}": $SRVVOL"; fi
-cleanup server $CAPIPRE-$CLUSTER
+#cleanup server $CAPIPRE-$CLUSTER
+cleanup_list server "" "" "$SRV"
 if test -n "$NOCASCADE"; then
 	cleanup_list loadbalancer 1 "" "$LBS"
 else

--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -7,12 +7,15 @@
 # (c) Kurt Garloff <garloff@osb-alliance.com>, 8/2021
 # SPDX-License-Identifier: Apache-2.0
 #
-# Usage: cleanup.sh [--full] [--force-fip] [--force-pvc] [CLUSTERNAME] [PREFIX]
+# Usage: cleanup.sh [--debug] [--verbose] [--full]
+#                   [--force-fip] [--force-pvc] [PREFIX [[CLUSTERNAMES]]
+# Note: The order of options args is fixed due to naive parser
 
 if test -z "$OPENSTACK"; then OPENSTACK="openstack"; fi
 
 declare -i DELETED=0
 
+if test "$1" == "--debug"; then DEBUG=1; shift; fi
 if test -n "$DEBUG"; then echo "# INFO: DEBUG set, won't delete anything for real"; DBG="Would have "; fi
 
 # collect list of resources, filtering for names
@@ -121,10 +124,10 @@ if test "$1" == "--verbose"; then VERBOSE=1; shift; fi
 if test "$1" == "--full"; then FULL=1; MGMTSRV=" management server and"; shift; fi
 if test "$1" == "--force-fip"; then FORCEFIP=1; shift; fi
 if test "$1" == "--force-pvc"; then FORCEPVC=1; shift; fi
-#if test -z "$1"; then CLUSTERS="${CLUSTER:-testcluster}"; else CLUSTERS="$1"; shift; fi
 #if test -z "$1"; then CAPIPRE="${CAPIPRE:-capi}"; else CAPIPRE="$1"; shift; fi
-if test -n "$1"; then CLUSTERS="$1"; shift; fi
+#if test -z "$1"; then CLUSTERS="${CLUSTER:-testcluster}"; else CLUSTERS="$1"; shift; fi
 if test -n "$1"; then CAPIPRE="$1"; shift; fi
+if test -n "$1"; then CLUSTERS="$@"; shift; fi
 # Try to guess CAPIPRE if it's unset
 if test -z "$CAPIPRE"; then
 	ENVIRONMENT=${ENVIRONMENT:-$OS_CLOUD}

--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -248,6 +248,8 @@ if test "$FULL" == "1"; then
 	echo "## Cleanup management server"
 	RTR=$(resourcelist router ${CAPIPRE}-rtr)
 	SUBNETS=$(resourcelist subnet ${CAPIPRE}-subnet)
+	FIP=$($OPENSTACK floating ip list -f value -c ID --tags "$CAPIPRE-mgmtcluster")
+	cleanup_list "floating ip" "" "" "$FIP"
 	if test -n "$RTR" -a -n "$SUBNETS"; then
 		echo $OPENSTACK router remove subnet $RTR $SUBNETS 1>&2
 		if test -z "$DEBUG"; then $OPENSTACK router remove subnet $RTR $SUBNETS; fi

--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -237,6 +237,7 @@ if test -n "$NGINX_SG"; then
 	if test -z "$DEBUG"; then $OPENSTACK security group delete $NGINX_SGS; fi
 fi
 # This should hit all volumes that were attached to the servers
+echo "### Hint: It's safe to ignore errors on already deleted volumes here"
 cleanup_list volume "" "" "$SRVVOL"
 #cleanup "image" ubuntu-capi-image
 cleanup "server group" "$CAPIPRE-$CLUSTER"
@@ -268,6 +269,7 @@ if test "$FULL" == "1"; then
 	cleanup "security group" ${CAPIPRE}-mgmt
 	cleanup "security group" ${CAPIPRE}-allow-
 	cleanup keypair ${CAPIPRE}-keypair
+	echo "## Hint: It's safe to ignore errors on an already deleted volume here"
 	cleanup_list volume "" "" "$CAPIVOL"
 	cleanup "application credential" ${CAPIPRE}-appcred
 	cleanup volume $CAPIPRE-mgmthost


### PR DESCRIPTION
Fixes #520.

We can do better in volume deletion:
* All volumes attached to our cluster nodes (workers and control plane) should be deleted. These are root volumes and possibly PVCs
* In addition, still identify them by name (just in case the servers have already been deleted) -- and we have a name now, thanks to #507
* WIth new option `--force-pvc`, we delete all volumes starting with `pvc` in the name.

We can also do better in FIP deletion:
* We have a tag now for the FIP attached to the mgmtcluster, delete FIP identified by it
* With the new option `--force-fip`, we also delete FIPs that are DOWN

This should improve `make fullclean` to deal with more sitations in case of strange failures.
SO it's a more robust mech for our e2e zuul testing.

We also offer the new target `make forceclean` also using the two new force options. SHould not normally be needed.
