### PR TITLE
Fix cleanup.sh deleting just the first cluster

### DIFF
--- a/terraform/files/bin/cleanup.sh
+++ b/terraform/files/bin/cleanup.sh
@@ -6,7 +6,7 @@ source ~/.bash_aliases
 
 export KUBECONFIG=~/.kube/config
 kubectl config use-context kind-kind
-CLUSTERS=$(kubectl get cluster --all-namespaces -o jsonpath='{range .items[]}{.metadata.name}{end}')
+CLUSTERS=$(kubectl get cluster --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 echo "Deleting all clusters: $CLUSTERS"
 echo "Hit ^C to interrupt"
 sleep 3


### PR DESCRIPTION
I found this bug now, where only the first cluster would get deleted.