### PR TITLE
Feat/limit kube apiserv mem

### DIFF
--- a/Release-Notes-R5.md
+++ b/Release-Notes-R5.md
@@ -228,6 +228,14 @@ With this followup PRs:
 - [#477](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/pull/477)
   Add migration steps for existing k8s clusters to adopt #432
 
+### kube-apiserver resource limits
+
+The kube-apiserver has memory and cpu resource limits set now such that it will not eat all
+CPU and RAM on the control plane nodes, creating trouble for etcd or the CNI controller running there.
+This will make the control-plane a bit more robust under extremely high load and cause it
+to fail more gracefully if finally overwhelmed.
+[#552](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/pull/552)
+
 ## Minor improvements
 
 - [#413](https://github.com/SovereignCloudStack/k8s-cluster-api-provider/pull/413)

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -236,7 +236,7 @@ spec:
         content: |
           #!/bin/bash
           MEM=$(free -m | grep '^Mem:' | awk '{print $2;}')
-          CPU=$(grep '^processor:' /proc/cpuinfo | wc -l)
+          CPU=$(grep '^processor[   ]' /proc/cpuinfo | wc -l)
           sed -i "/^ *requests:/i\      limits:\n        memory: $((10+3*$MEM/4))M\n        cpu: $((750*$CPU))m" /etc/kubernetes/manifests/kube-apiserver.yaml
     postKubeadmCommands:
       - if test "${ETCD_UNSAFE_FS}" = "true"; then mount -o remount,barrier=0,commit=20 /; sed -i 's@errors=remount-ro@errors=remount-ro,barrier=0,commit=20@' /etc/fstab; fi

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -235,9 +235,11 @@ spec:
         permissions: "0755"
         content: |
           #!/bin/bash
+          grep '^      limits:' /etc/kubernetes/manifests/kube-apiserver.yaml >/dev/null 2>&1 && exit 0
           MEM=$(free -m | grep '^Mem:' | awk '{print $2;}')
-          CPU=$(grep '^processor[   ]' /proc/cpuinfo | wc -l)
+          CPU=$(grep '^processor' /proc/cpuinfo | wc -l)
           sed -i "/^ *requests:/i\      limits:\n        memory: $((10+3*$MEM/4))M\n        cpu: $((750*$CPU))m" /etc/kubernetes/manifests/kube-apiserver.yaml
+          sed -i "/^ *requests:/a\        memory: 512M" /etc/kubernetes/manifests/kube-apiserver.yaml
     postKubeadmCommands:
       - if test "${ETCD_UNSAFE_FS}" = "true"; then mount -o remount,barrier=0,commit=20 /; sed -i 's@errors=remount-ro@errors=remount-ro,barrier=0,commit=20@' /etc/fstab; fi
       - /root/tweak-kubeapi-memlimit.sh

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -236,7 +236,8 @@ spec:
         content: |
           #!/bin/bash
           MEM=$(free -m | grep '^Mem:' | awk '{print $2;}')
-          sed -i "/^ *requests:/i\      limits:\n        memory: $((32+3*$MEM/4))M" /etc/kubernetes/manifests/kube-apiserver.yaml
+          CPU=$(grep '^processor:' /proc/cpuinfo | wc -l)
+          sed -i "/^ *requests:/i\      limits:\n        memory: $((10+3*$MEM/4))M\n        cpu: $((750*$CPU))m" /etc/kubernetes/manifests/kube-apiserver.yaml
     postKubeadmCommands:
       - if test "${ETCD_UNSAFE_FS}" = "true"; then mount -o remount,barrier=0,commit=20 /; sed -i 's@errors=remount-ro@errors=remount-ro,barrier=0,commit=20@' /etc/fstab; fi
       - /root/tweak-kubeapi-memlimit.sh

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -230,9 +230,16 @@ spec:
 
           [Install]
           WantedBy=timers.target
+      - path: /root/tweak-kubeapi-memlimit.sh
+        owner: root:root
+        permissions: "0755"
+        content: |
+          #!/bin/bash
+          MEM=$(free -m | grep '^Mem:' | awk '{print $2;}')
+          sed -i "/^ *requests:/i\      limits:\n        memory: $((32+3*$MEM/4))M" /etc/kubernetes/manifests/kube-apiserver.yaml
     postKubeadmCommands:
       - if test "${ETCD_UNSAFE_FS}" = "true"; then mount -o remount,barrier=0,commit=20 /; sed -i 's@errors=remount-ro@errors=remount-ro,barrier=0,commit=20@' /etc/fstab; fi
-      - MEM=$(free -m | grep '^Mem:' | sed 's/^Mem: *\([0-9]*\) .*$/\1/'); sed -i "/^ *requests:/i\      limits:\n        memory: $((32+3*$MEM/4))M" /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /root/tweak-kubeapi-memlimit.sh
       - sync; systemctl restart kubelet    # We should no longer need this
       - while test -z "$EPID"; do sleep 5; EPID=`pgrep etcd`; done; renice -10 $EPID; ionice -c2 -n0 -p $EPID
       - systemctl enable etcd-defrag.service
@@ -254,7 +261,7 @@ spec:
       - systemctl daemon-reload
       - systemctl restart containerd.service
       # Install etcdctl
-      - ETCDCTL_VERSION=v3.5.7
+      - ETCDCTL_VERSION=v3.5.9
       - curl -L https://github.com/coreos/etcd/releases/download/$${ETCDCTL_VERSION}/etcd-$${ETCDCTL_VERSION}-linux-amd64.tar.gz -o /tmp/etcd-$${ETCDCTL_VERSION}-linux-amd64.tar.gz
       - tar xzvf /tmp/etcd-$${ETCDCTL_VERSION}-linux-amd64.tar.gz -C /tmp/
       - sudo cp /tmp/etcd-$${ETCDCTL_VERSION}-linux-amd64/etcdctl /usr/local/bin/

--- a/terraform/files/template/cluster-template.yaml
+++ b/terraform/files/template/cluster-template.yaml
@@ -232,6 +232,7 @@ spec:
           WantedBy=timers.target
     postKubeadmCommands:
       - if test "${ETCD_UNSAFE_FS}" = "true"; then mount -o remount,barrier=0,commit=20 /; sed -i 's@errors=remount-ro@errors=remount-ro,barrier=0,commit=20@' /etc/fstab; fi
+      - MEM=$(free -m | grep '^Mem:' | sed 's/^Mem: *\([0-9]*\) .*$/\1/'); sed -i "/^ *requests:/i\      limits:\n        memory: $((32+3*$MEM/4))M" /etc/kubernetes/manifests/kube-apiserver.yaml
       - sync; systemctl restart kubelet    # We should no longer need this
       - while test -z "$EPID"; do sleep 5; EPID=`pgrep etcd`; done; renice -10 $EPID; ionice -c2 -n0 -p $EPID
       - systemctl enable etcd-defrag.service


### PR DESCRIPTION
This limits both CPU and Mem usage to 75% of what the control plane node offers.
With our default sizing (SCS-2V-4), this means max 1.5 vCPUs and 2.875GiB of memory for kube-apiserver.
Goal is to avoid an overwhelmed kube-apiserver causing the control plane node (and especially etcd) to become completely dysfunctional.
Fixes #516.