### PR TITLE
Fix grepping of PREFIX in Makefile

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -8,7 +8,7 @@ SHELL=/bin/bash
 SED ?= sed
 #ENVIRONMENT = gx-bc
 OPENSTACK ?= openstack
-CONSOLE = capi-mgmtcluster
+CONSOLE = $(PREFIX)-mgmtcluster
 #TESTCLUSTER ?= testcluster
 
 # check for openstack credentials
@@ -39,8 +39,8 @@ ifeq ($(TESTCLUSTER),)
 TESTCLUSTER=$(shell ( grep '^testcluster_name' environments/environment-$(ENVIRONMENT).tfvars || echo testcluster ) | $(SED) 's@^testcluster_name[^=]*= *"*\([^"]*\).*$$@\1@' )
 endif
 
-PREFIX:=$(shell (grep '^prefix *=' environments/environment-${ENVIRONMENT}.tfvars || echo capi | $(SED) -e 's/^[^=]*= *//' -e 's/"//g'))
-MGMTCLUSTERNAME:=$(shell ($(OPENSTACK) --os-cloud $(ENVIRONMENT) server list --name "$(PREFIX)-mgmtcluster" -c Name -f value))
+PREFIX=$(shell (grep '^prefix *=' environments/environment-${ENVIRONMENT}.tfvars || echo capi ) | $(SED) -e 's/^[^=]*= *//' -e 's/"//g')
+MGMTCLUSTERNAME=$(shell ($(OPENSTACK) --os-cloud $(ENVIRONMENT) server list --name "$(PREFIX)-mgmtcluster" -c Name -f value))
 
 GITBRANCH=$(shell git branch | grep '^*' | $(SED) 's/^* //')
 # Specify a branch, tag or commit to checkout on the mgmtcluster
@@ -106,13 +106,11 @@ clean: init
 	@rm -f .kubeconfig.$(ENVIRONMENT) $(TESTCLUSTER).yaml.$(ENVIRONMENT) clusterctl.$(TESTCLUSTER).yaml.$(ENVIRONMENT) $(TESTCLUSTER)-config.yaml.$(ENVIRONMENT)
 
 fullclean:
-	prefix=$$(grep '^prefix *=' environments/environment-${ENVIRONMENT}.tfvars | $(SED) -e 's/^[^=]*= *//' -e 's/"//g'); \
 	./cleanup/cleanup.sh --verbose --full
 	@if test -e ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); then source ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); ssh-keygen -R $$MGMTCLUSTER_ADDRESS -f ~/.ssh/known_hosts; rm -f .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); fi
 	$(MAKE) clean
 
 forceclean:
-	prefix=$$(grep '^prefix *=' environments/environment-${ENVIRONMENT}.tfvars | $(SED) -e 's/^[^=]*= *//' -e 's/"//g'); \
 	./cleanup/cleanup.sh --verbose --full --force-fip --force-pvc
 	@if test -e ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); then source ./.deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); ssh-keygen -R $$MGMTCLUSTER_ADDRESS -f ~/.ssh/known_hosts; rm -f .deploy.MGMTCLUSTER_ADDRESS.$(ENVIRONMENT); fi
 	$(MAKE) clean


### PR DESCRIPTION
It fixes changes from #510

Also change `:=` to just `=` so openstack command in *MGMTCLUSTERNAME* runs only when is invoked. *Make* autocompletion is also quicker.

Unnecessary prefix grepping is removed in full/forceclean. *CONSOLE* variable is now dynamic, based on *PREFIX*