### PR TITLE
Enhance the logic to wait for k8s resources in `create_cluster.sh`

### DIFF
--- a/terraform/files/bin/create_cluster.sh
+++ b/terraform/files/bin/create_cluster.sh
@@ -4,6 +4,25 @@
 ## license: Apache-2.0
 
 STARTTIME=$(date +%s)
+
+wait_for_k8s_resource_matching() {
+  local SLEEP=0
+  until kubectl $2 get $1 -o=jsonpath='{.metadata.name}' >/dev/null 2>&1; do
+    echo "[$SLEEP] waiting for $1"
+    sleep 10
+    let SLEEP+=10
+  done
+}
+
+wait_for_k8s_resources_matching() {
+  local SLEEP=0
+  until [ ! -z $(kubectl $3 get $2 --template '{{if len .items}}{{with index .items 0}}{{.metadata.name}}{{end}}{{end}}') ]; do
+    echo "[$SLEEP] waiting for $1"
+    sleep 10
+    let SLEEP+=10
+  done
+}
+
 # variables
 . ~/.capi-settings
 . ~/bin/cccfg.inc
@@ -149,15 +168,12 @@ fi
 echo "# apply configuration and deploy cluster ${CLUSTER_NAME}"
 kubectl apply -f ~/${CLUSTER_NAME}/${CLUSTER_NAME}-config.yaml || exit 3
 
-#Waiting for Clusterstate Ready
+# Waiting for Cluster=Ready
+wait_for_k8s_resource_matching kubeadmcontrolplanes/${CLUSTER_NAME}-control-plane
+wait_for_k8s_resources_matching machines/${CLUSTER_NAME} "machines -l cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}"
+
 echo "# Waiting for Cluster=Ready"
-sync
-sleep 2
-#wget https://gx-scs.okeanos.dev --quiet -O /dev/null
-#ping -c1 -w2 9.9.9.9 >/dev/null 2>&1
-if test "$CLUSTER_EXISTS" != "1"; then sleep 12; fi
-kubectl wait --timeout=5s --for=condition=certificatesavailable kubeadmcontrolplanes -l cluster.x-k8s.io/cluster-name=${CLUSTER_NAME} >/dev/null 2>&1 || sleep 25
-kubectl wait --timeout=14m --for=condition=certificatesavailable kubeadmcontrolplanes -l cluster.x-k8s.io/cluster-name=${CLUSTER_NAME} || exit 1
+kubectl wait --timeout=14m --for=condition=certificatesavailable kubeadmcontrolplanes/${CLUSTER_NAME}-control-plane || exit 1
 kubectl wait --timeout=8m --for=condition=Ready machine -l cluster.x-k8s.io/control-plane,cluster.x-k8s.io/cluster-name=${CLUSTER_NAME} || exit 4
 
 kubectl get secrets "${CLUSTER_NAME}-kubeconfig" --output go-template='{{ .data.value | base64decode }}' >"${KUBECONFIG_WORKLOADCLUSTER}" || exit 5
@@ -178,12 +194,7 @@ until kubectl $KCONTEXT api-resources; do
 done
 
 # CNI
-SLEEP=0
-until kubectl $KCONTEXT -n kube-system get daemonset/kube-proxy -o=jsonpath='{.metadata.name}' >/dev/null 2>&1; do
-  echo "[$SLEEP] waiting for kube-proxy"
-  sleep 10
-  let SLEEP+=10
-done
+wait_for_k8s_resource_matching daemonset/kube-proxy "${KCONTEXT} -n kube-system"
 
 echo "waiting for kube-proxy to become ready"
 kubectl $KCONTEXT -n kube-system wait --for=condition=ready --timeout=5m pods -l k8s-app=kube-proxy

--- a/terraform/files/bin/wait.sh
+++ b/terraform/files/bin/wait.sh
@@ -3,7 +3,7 @@
 SLEEP=0
 while [ ! -f /var/lib/cloud/instance/boot-finished ]
 do
-	echo "[$SLEEP] waiting for cloud-init to finish"
+	echo "[${SLEEP}s] Waiting for cloud-init to finish"
 	sleep 5
     SLEEP=$(( SLEEP + 5 ))
 done


### PR DESCRIPTION
This PR add additional logic to wait for k8s resources `` and `` to be created before `kubectl wait` is called. This adds two new bash functions for repetitive code.

Closes #553