### PR TITLE
Fix warning `grep: warning: stray \ before -` in `cleanup/cleanup.sh`

### DIFF
--- a/terraform/cleanup/cleanup.sh
+++ b/terraform/cleanup/cleanup.sh
@@ -181,10 +181,10 @@ echo "## Deleting clusters $CLUSTERS"
 
 for CLUSTER in $CLUSTERS; do
 
-CAPIPRE2X="k8s\-clusterapi\-cluster"
-CAPIPRE2ALL="k8s\-clusterapi\-cluster\-\(default\|$CLUSTER\)\-$CLUSTER"
-CAPIPRE3X="k8s\-cluster"
-CAPIPRE3ALL="k8s\-cluster\-\(default\|$CLUSTER\)\-$CLUSTER"
+CAPIPRE2X="k8s-clusterapi-cluster"
+CAPIPRE2ALL="k8s-clusterapi-cluster-\(default\|$CLUSTER\)-$CLUSTER"
+CAPIPRE3X="k8s-cluster"
+CAPIPRE3ALL="k8s-cluster-\(default\|$CLUSTER\)-$CLUSTER"
 
 echo "### Deleting cluster $CLUSTER"
 # cleanup loadbalancers


### PR DESCRIPTION
This removes some leading `\` before `-` used for `grep`.