### PR TITLE
Add option to specify external net via ID

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,13 +29,13 @@ Parameters controlling the Cluster-API management server (capi management server
 
 Parameters controlling both management server creation and cluster creation:
 
-| environment         | clusterctl.yaml                 | provenance | default                              | meaning                                                                                                                      |
-|---------------------|---------------------------------|------------|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `cloud_provider`    | `OPENSTACK_CLOUD`               | capo       |                                      | `OS_CLOUD` name in clouds.yaml                                                                                               |
-| `external`          | `OPENSTACK_EXTERNAL_NETWORK_ID` | capo       | `""`                                 | Name/ID of the external (public) OpenStack network, default "" uses the detected external network                            |
-| `dns_nameservers`   | `OPENSTACK_DNS_NAMESERVERS`     | capo       | `[ "5.1.66.255", "185.150.99.255" ]` | Array of nameservers for capi mgmt server and for cluster nodes, replace the FF MUC defaults with local servers if available |
-| `availability_zone` | `OPENSTACK_FAILURE_DOMAIN`      | capo       |                                      | Availability Zone(s) for the mgmt node / workload clusters                                                                   |
-| `kind_mtu`          | `MTU_VALUE`                     | SCS        | `0`                                  | MTU for the mgmt server; Calico is set 50 bytes smaller; 0 means autodetection                                               |
+| environment              | clusterctl.yaml                 | provenance | default                              | meaning                                                                                                                                  |
+|--------------------------|---------------------------------|------------|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `cloud_provider`         | `OPENSTACK_CLOUD`               | capo       |                                      | `OS_CLOUD` name in clouds.yaml                                                                                                           |
+| `external`/`external_id` | `OPENSTACK_EXTERNAL_NETWORK_ID` | capo       | `""`                                 | Name/ID of the external (public) OpenStack network, default "" uses the detected external network (for clouds with one external network) |
+| `dns_nameservers`        | `OPENSTACK_DNS_NAMESERVERS`     | capo       | `[ "5.1.66.255", "185.150.99.255" ]` | Array of nameservers for capi mgmt server and for cluster nodes, replace the FF MUC defaults with local servers if available             |
+| `availability_zone`      | `OPENSTACK_FAILURE_DOMAIN`      | capo       |                                      | Availability Zone(s) for the mgmt node / workload clusters                                                                               |
+| `kind_mtu`               | `MTU_VALUE`                     | SCS        | `0`                                  | MTU for the mgmt server; Calico is set 50 bytes smaller; 0 means autodetection                                                           |
 
 ### Parameters clusters
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,13 +29,13 @@ Parameters controlling the Cluster-API management server (capi management server
 
 Parameters controlling both management server creation and cluster creation:
 
-| environment              | clusterctl.yaml                 | provenance | default                              | meaning                                                                                                                                  |
-|--------------------------|---------------------------------|------------|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| `cloud_provider`         | `OPENSTACK_CLOUD`               | capo       |                                      | `OS_CLOUD` name in clouds.yaml                                                                                                           |
-| `external`/`external_id` | `OPENSTACK_EXTERNAL_NETWORK_ID` | capo       | `""`                                 | Name/ID of the external (public) OpenStack network, default "" uses the detected external network (for clouds with one external network) |
-| `dns_nameservers`        | `OPENSTACK_DNS_NAMESERVERS`     | capo       | `[ "5.1.66.255", "185.150.99.255" ]` | Array of nameservers for capi mgmt server and for cluster nodes, replace the FF MUC defaults with local servers if available             |
-| `availability_zone`      | `OPENSTACK_FAILURE_DOMAIN`      | capo       |                                      | Availability Zone(s) for the mgmt node / workload clusters                                                                               |
-| `kind_mtu`               | `MTU_VALUE`                     | SCS        | `0`                                  | MTU for the mgmt server; Calico is set 50 bytes smaller; 0 means autodetection                                                           |
+| environment              | clusterctl.yaml                 | provenance | default                              | meaning                                                                                                                                                                                           |
+|--------------------------|---------------------------------|------------|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cloud_provider`         | `OPENSTACK_CLOUD`               | capo       |                                      | `OS_CLOUD` name in clouds.yaml                                                                                                                                                                    |
+| `external`/`external_id` | `OPENSTACK_EXTERNAL_NETWORK_ID` | capo       | `""`                                 | Name/ID of the external (public) OpenStack network, default "" uses the detected external network (for clouds with one external network). Required for clouds with more than one external network |
+| `dns_nameservers`        | `OPENSTACK_DNS_NAMESERVERS`     | capo       | `[ "5.1.66.255", "185.150.99.255" ]` | Array of nameservers for capi mgmt server and for cluster nodes, replace the FF MUC defaults with local servers if available                                                                      |
+| `availability_zone`      | `OPENSTACK_FAILURE_DOMAIN`      | capo       |                                      | Availability Zone(s) for the mgmt node / workload clusters                                                                                                                                        |
+| `kind_mtu`               | `MTU_VALUE`                     | SCS        | `0`                                  | MTU for the mgmt server; Calico is set 50 bytes smaller; 0 means autodetection                                                                                                                    |
 
 ### Parameters clusters
 

--- a/terraform/environments/environment-default.tfvars
+++ b/terraform/environments/environment-default.tfvars
@@ -4,6 +4,7 @@ prefix               = "<prefix_for_openstack_resources>"  # defaults to "capi"
 cloud_provider       = "<name_for_provider>"
 availability_zone    = "<az>"
 external             = "<external_network_name>"  # defaults to "" using auto-detection
+external_id          = "<external_network_ID>"    # defaults to "" using auto-detection
 dns_nameservers      = [ "DNS_IP1", "DNS_IP2" ]	  # defaults to [ "5.1.66.255", "185.150.99.255" ] (FF MUC)
 kind_flavor          = "<flavor>"                 # defaults to SCS-2V-4  (larger does not hurt)
 ssh_username         = "<username_for_ssh>"	  # defaults to "ubuntu"

--- a/terraform/files/template/clusterctl.yaml.tmpl
+++ b/terraform/files/template/clusterctl.yaml.tmpl
@@ -66,7 +66,7 @@ RESTRICT_KUBEAPI: "[ %{ for cidr in restrict_kubeapi ~} ${cidr}, %{ endfor ~} ]"
 
 # Openstack external Network ID
 # hint: openstack network list --external -f value -c ID
-OPENSTACK_EXTERNAL_NETWORK_ID: ${external}
+OPENSTACK_EXTERNAL_NETWORK_ID: ${external_id}
 
 OPENSTACK_DNS_NAMESERVERS: "[ %{ for dnsip in dns_nameservers ~} ${dnsip}, %{ endfor ~} ]"
 

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -11,12 +11,14 @@ resource "openstack_identity_application_credential_v3" "appcred" {
 }
 
 data "openstack_networking_network_v2" "extnet" {
-  external = true
+  external   = true
+  name       = var.external != "" ? var.external : null
+  network_id = var.external_id != "" ? var.external_id : null
 }
 
 # - management cluster -
 resource "openstack_networking_floatingip_v2" "mgmtcluster_floatingip" {
-  pool        = var.external != "" ? var.external : data.openstack_networking_network_v2.extnet.name
+  pool        = data.openstack_networking_network_v2.extnet.name
   depends_on  = [openstack_networking_router_interface_v2.router_interface]
   description = "Floating IP for the ${var.prefix} management cluster node"
   tags = [
@@ -278,7 +280,7 @@ resource "terraform_data" "mgmtcluster_bootstrap_files" {
       deploy_occm                    = var.deploy_occm,
       dns_nameservers                = var.dns_nameservers,
       etcd_unsafe_fs                 = var.etcd_unsafe_fs,
-      external                       = var.external != "" ? var.external : data.openstack_networking_network_v2.extnet.name,
+      external_id                    = data.openstack_networking_network_v2.extnet.id,
       image_registration_extra_flags = var.image_registration_extra_flags,
       kube_image_raw                 = var.kube_image_raw,
       kubernetes_version             = var.kubernetes_version,

--- a/terraform/neutron.tf
+++ b/terraform/neutron.tf
@@ -65,14 +65,10 @@ resource "openstack_networking_subnet_v2" "subnet_mgmt" {
   }
 }
 
-data "openstack_networking_network_v2" "external" {
-  name = var.external != "" ? var.external : data.openstack_networking_network_v2.extnet.name
-}
-
 resource "openstack_networking_router_v2" "router_mgmt" {
   name                    = "${var.prefix}-rtr"
   description             = "router for mgmtcluster (managed by terraform)"
-  external_network_id     = data.openstack_networking_network_v2.external.id
+  external_network_id     = data.openstack_networking_network_v2.extnet.id
   availability_zone_hints = [var.availability_zone] # comment this out if your cloud does not have network AZs
 }
 

--- a/terraform/neutron.tf
+++ b/terraform/neutron.tf
@@ -65,10 +65,14 @@ resource "openstack_networking_subnet_v2" "subnet_mgmt" {
   }
 }
 
+data "openstack_networking_network_v2" "external" {
+  name = data.openstack_networking_network_v2.extnet.name
+}
+
 resource "openstack_networking_router_v2" "router_mgmt" {
   name                    = "${var.prefix}-rtr"
   description             = "router for mgmtcluster (managed by terraform)"
-  external_network_id     = data.openstack_networking_network_v2.extnet.id
+  external_network_id     = data.openstack_networking_network_v2.external.id
   availability_zone_hints = [var.availability_zone] # comment this out if your cloud does not have network AZs
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,10 +39,17 @@ variable "availability_zone" {
 }
 
 variable "external" {
-  description = "external/public network for access"
+  description = "external/public network name for access"
   type        = string
   default     = ""
   # default   = data.openstack_networking_network_v2.extnet.name
+}
+
+variable "external_id" {
+  description = "external/public network ID for access"
+  type        = string
+  default     = ""
+  # default   = data.openstack_networking_network_v2.extnet.id
 }
 
 variable "ssh_username" {


### PR DESCRIPTION
Fixes #572

This commit should resolve these problems:
OPENSTACK_EXTERNAL_NETWORK_ID was prefilled with external network name instead of ID what causes external net autodetection by CAPO - multiple ext nets cause error. Documentation says that 'external' can be name/id of external network which doesnt work - introduce external_id parameter. Autodetection of external network is improved - when multiple ext net exists, it can be specified via external/external_id