### PR TITLE
Revert "Remove unnecessary keystoneauth patch (#580)"

### DIFF
--- a/terraform/files/bin/prepare_openstack.sh
+++ b/terraform/files/bin/prepare_openstack.sh
@@ -4,6 +4,8 @@ export OS_CLOUD=$(yq eval '.OPENSTACK_CLOUD' ~/cluster-defaults/clusterctl.yaml)
 
 #install Openstack CLI
 sudo apt-get install --no-install-recommends --no-install-suggests -y python3-openstackclient python3-octaviaclient
+# fix bug 1876317
+sudo patch -p2 -N -d /usr/lib/python3/dist-packages/keystoneauth1 < /tmp/fix-keystoneauth-plugins-unversioned.diff
 
 # convenience
 echo "export OS_CLOUD=\"$OS_CLOUD\"" >> $HOME/.bash_aliases

--- a/terraform/files/fix-keystoneauth-plugins-unversioned.diff
+++ b/terraform/files/fix-keystoneauth-plugins-unversioned.diff
@@ -1,0 +1,42 @@
+This is a minimal version of
+
+commit ad46262148e7b099e6c7239887e20ade5b8e6ac8
+Author: Lance Bragstad <lbragstad@gmail.com>
+Date:   Fri May 1 01:02:12 2020 +0000
+
+    Inject /v3 in token path for v3 plugins
+    
+    Without this, it's possible to get HTTP 404 errors from keystone if
+    OS_AUTH_URL isn't versioned (e.g., https://keystone.example.com/ instead
+    of https://keystone.example.com/v3), even if OS_IDENTITY_API is set to
+    3.
+    
+    This commit works around this issue by checking the AUTH_URL before
+    building the token_url and appending '/v3' to the URL before sending the
+    request.
+    
+    Closes-Bug: 1876317
+    
+    Change-Id: Ic75f0c9b36022b884105b87bfe05f4f8292d53b2
+
+
+diff --git a/keystoneauth1/identity/v3/base.py b/keystoneauth1/identity/v3/base.py
+index 20a86db..bcd6441 100644
+--- a/keystoneauth1/identity/v3/base.py
++++ b/keystoneauth1/identity/v3/base.py
+@@ -173,9 +173,13 @@ class Auth(BaseAuth):
+             if self.system_scope == 'all':
+                 body['auth']['scope'] = {'system': {'all': True}}
+ 
++        token_url = self.token_url
++
++        if not self.auth_url.rstrip('/').endswith('v3'):
++            token_url = '%s/v3/auth/tokens' % self.auth_url.rstrip('/')
++
+         # NOTE(jamielennox): we add nocatalog here rather than in token_url
+         # directly as some federation plugins require the base token_url
+-        token_url = self.token_url
+         if not self.include_catalog:
+             token_url += '?nocatalog'
+ 
+

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -329,6 +329,11 @@ resource "terraform_data" "mgmtcluster_bootstrap_files" {
     destination = "/home/${var.ssh_username}/cluster-defaults/cluster-template.yaml"
   }
 
+  provisioner "file" {
+    source      = "files/fix-keystoneauth-plugins-unversioned.diff"
+    destination = "/tmp/fix-keystoneauth-plugins-unversioned.diff"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "chmod 0600 /home/${var.ssh_username}/.ssh/id_rsa /home/${var.ssh_username}/cluster-defaults/clusterctl.yaml /home/${var.ssh_username}/cluster-defaults/cloud.conf /home/${var.ssh_username}/.config/openstack/clouds.yaml",


### PR DESCRIPTION
This reverts commit d9fd9050ea69f916487b97784fa5206fd42e9e68.

This patch is still needed for the Ubuntu 20.04.

I found that Ubuntu 20.04 is used in some environments.

Without this patch, OpenStack commands end up with `Not Found (HTTP 404)` error.