### PR TITLE
Fix daily pipeline

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -49,11 +49,3 @@
     unlabel-on-update-e2e-quick-test:
       jobs:
       - noop
-    periodic-daily:
-      jobs:
-      - k8s-cluster-api-provider-e2e-conformance:
-          branches:
-          - main
-          - release/v6.0.0
-          vars:
-            git_reference: "{{ zuul.branch }}"


### PR DESCRIPTION
A daily pipeline did not work for release/v6.0.0 branch. Zuul's behavior can be summarized as follows: when determining what tasks to execute on the release/v6.0.0 branch, it focuses solely on the project definition within the release/v6.0.0 branch, not the main branch. Additionally, it examines the project definitions in the configuration project, and after gathering the jobs to be executed, it filters them down by matching branches.

Refer to the second paragraph of the docs: https://zuul-ci.org/docs/zuul/latest/config/project.html

To resolve this issue, this commit removes the daily pipeline definition from the main branch. Instead, the project's daily pipeline will now be configured in the Zuul configuration project. See related PR: https://github.com/SovereignCloudStack/zuul-config/pull/31