### PR TITLE
Add "stale" GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+---
+name: Mark and close stale issues
+
+"on":
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        exempt-all-issue-assignees: true  #  the issues with an assignee will not be marked as stale automatically
+        stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment, or this will be closed in 60 days."
+        close-issue-message: "This issue was closed because it has been stalled for 60 days with no activity."
+        stale-issue-label: "stale"
+        days-before-issue-stale: 30
+        days-before-issue-close: 60
+        days-before-pr-stale: -1  # disabled for PRs
+        days-before-pr-close: -1  # disabled for PRs

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,7 @@ jobs:
         stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment, or this will be closed in 60 days."
         close-issue-message: "This issue was closed because it has been stalled for 60 days with no activity."
         stale-issue-label: "stale"
+        exempt-issue-labels: "longterm,epic"
         days-before-issue-stale: 30
         days-before-issue-close: 60
         days-before-pr-stale: -1  # disabled for PRs


### PR DESCRIPTION
This PR adds a GitHub action that automatically labels issues as 'stale' following 30 days of inactivity and subsequently, after an additional 60 days of inactivity, proceeds to close the issues

Inspiration taken from https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues

Exceptions:
- the issues with an assignee will not be marked as stale automatically
- the issues with  labels: "longterm,epic" will not be marked as stale automatically

- disabled for PRs (for now)

Closes https://github.com/SovereignCloudStack/k8s-cluster-api-provider/issues/613