### PR TITLE
Preserves (possible) additional docker-daemon settings

### DIFF
--- a/terraform/files/bin/get_mtu.sh
+++ b/terraform/files/bin/get_mtu.sh
@@ -20,8 +20,7 @@ if test "$CLOUDMTU" == "0"; then
 	echo "Detected MTU $CLOUDMTU (dev $DEV)"
 	DOCKERMTU=$((CLOUDMTU/8*8))
 	if test -e /tmp/daemon.json && grep '"mtu": 0' /tmp/daemon.json >/dev/null; then
-		if test "$CLOUDMTU" == "1500"; then rm /tmp/daemon.json; fi
-		sed -i "s/: 0/: $DOCKERMTU/" /tmp/daemon.json
+		sed -i "s/\"mtu\": 0/\"mtu\": $DOCKERMTU/" /tmp/daemon.json
 	fi
 fi
 CALICOMTU=$(((CLOUDMTU-50)/8*8))


### PR DESCRIPTION
Issue #418 is about using a proxy server in this repo. One portion of this issues is to set the proxy settings for the docker daemon in /etc/docker/daemon.json. This config file is currently provisioned in case the terraform variable mtu is set. If the mtu is set to "0" (default) and the configuration script detects a standard mtu of 1500 for the connecting interface, the file is disposed completely. In order to add other settings, the file should be preserved even if the mtu is standard 1500

Signed-off-by: Malte Münch <muench@b1-systems.de>
