### PR TITLE
New config-setting no_proxy

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -39,6 +39,7 @@ Parameters controlling both management server creation and cluster creation:
 | `kind_mtu`             | `MTU_VALUE`                     | SCS        | `0`                                  | MTU for the mgmt server; Calico is set 50 bytes smaller; 0 means autodetection                                               |
 | `restrict_mgmt_server` |                                 | SCS        | `["0.0.0.0/0"]`                      | Allows restricting access to the management server by the given list of CIDRs. Empty value (default) means public.           |
 |  http_proxy            |                                 | SCS        |                                      | Global setting for HTTP Proxy is set on the management host including all cluster-api components running in the bootstrap-cluster.  Specify with protocol: e.g "http://10.10.10.10:3128"
+|  no_proxy            |                                 | SCS        |                                      | Global setting for HTTP Proxy exception list. If `http_proxy` is not set this setting has no effect. If `http_proxy` is set, the default value for the `NO_PROXY` environment variable on all affected components is set to `.svc,.svc.cluster,.svc.cluster.local,127.0.0.0/8,169.254.169.254/32,fd00:ec2::254/128,${var.node_cidr},${var.pod_cidr},${var.service_cidr}`. The content of `no_proxy` is appended to this list. This setting has no effect on apt and snap commands, the way `http_proxy` is set for apt and snap does not allow the configuration of proxy exceptions.
 
 ### Parameters clusters
 

--- a/terraform/files/bin/configure_containerd_proxy.sh
+++ b/terraform/files/bin/configure_containerd_proxy.sh
@@ -14,7 +14,7 @@
 #     [Service]
 #     Environment="HTTP_PROXY=<$HTTP_PROXY from /etc/profile.d/proxy.sh>"
 #     Environment="HTTPS_PROXY=<$HTTP_PROXY from /etc/profile.d/proxy.sh>"
-#     Environment="NO_PROXY=127.0.0.0/8,172.18.0.0/16,fc00:f853:ccd:e793::/64,10.96.0.0/16,10.244.0.0/16,kind-control-plane,.svc,.svc.cluster,.svc.cluster.local"
+#     Environment="NO_PROXY=<$NO_PROXY from /etc/profile.d/proxy.sh>"
 #   ```
 # - Injects temporary YAML file into $1 (cluster-template.yaml) file (using `yq` in place edit).
 #   Temporary file is injected to the `KubeadmControlPlaneTemplate.spec.template.spec.kubeadmConfigSpec.files` that specifies extra files to be
@@ -40,7 +40,7 @@ export CLUSTER_TEMPLATE_SNIPPET=clustertemplate_snippet
 echo "[Service]" > $SYSTEMD_CONFIG_CONTENT
 echo "Environment=\"HTTP_PROXY=$HTTP_PROXY\"" >> $SYSTEMD_CONFIG_CONTENT
 echo "Environment=\"HTTPS_PROXY=$HTTP_PROXY\"" >> $SYSTEMD_CONFIG_CONTENT
-echo "Environment=\"NO_PROXY=127.0.0.0/8,172.18.0.0/16,fc00:f853:ccd:e793::/64,10.96.0.0/16,10.244.0.0/16,kind-control-plane,.svc,.svc.cluster,.svc.cluster.local\"" >> $SYSTEMD_CONFIG_CONTENT
+echo "Environment=\"NO_PROXY=$NO_PROXY\"" >> $SYSTEMD_CONFIG_CONTENT
 
 
 yq --null-input '

--- a/terraform/mgmtcluster.tf
+++ b/terraform/mgmtcluster.tf
@@ -98,7 +98,7 @@ write_files:
         "proxies": {
           "http-proxy": "${var.http_proxy}",
           "https-proxy": "${var.http_proxy}",
-          "no-proxy": "127.0.0.0/8,172.18.0.0/16,fc00:f853:ccd:e793::/64,10.96.0.0/16,10.244.0.0/16,kind-control-plane,.svc,.svc.cluster,.svc.cluster.local"
+          "no-proxy": ".svc,.svc.cluster,.svc.cluster.local,127.0.0.0/8,169.254.169.254/32,fd00:ec2::254/128,${var.node_cidr},${var.pod_cidr},${var.service_cidr},${var.no_proxy}"
         },
         %{endif}
         "mtu": ${var.kind_mtu}
@@ -119,8 +119,8 @@ write_files:
         export HTTPS_PROXY=$PROXY
         export http_proxy=$PROXY
         export https_proxy=$PROXY
-        export NO_PROXY=172.18.0.0/16,fc00:f853:ccd:e793::/64,10.96.0.0/16,10.244.0.0/16,kind-control-plane,.svc,.svc.cluster,.svc.cluster.local
-        export no_proxy=172.18.0.0/16,fc00:f853:ccd:e793::/64,10.96.0.0/16,10.244.0.0/16,kind-control-plane,.svc,.svc.cluster,.svc.cluster.local
+        export NO_PROXY=".svc,.svc.cluster,.svc.cluster.local,127.0.0.0/8,169.254.169.254/32,fd00:ec2::254/128,${var.node_cidr},${var.pod_cidr},${var.service_cidr},${var.no_proxy}"
+        export no_proxy=".svc,.svc.cluster,.svc.cluster.local,127.0.0.0/8,169.254.169.254/32,fd00:ec2::254/128,${var.node_cidr},${var.pod_cidr},${var.service_cidr},${var.no_proxy}"
       fi
     owner: root:root
     permissions: '0644'
@@ -132,7 +132,7 @@ write_files:
           "default": {
             "httpProxy": "${var.http_proxy}",
             "httpsProxy": "${var.http_proxy}",
-            "noProxy": "127.0.0.0/8,172.18.0.0/16,fc00:f853:ccd:e793::/64,10.96.0.0/16,10.244.0.0/16,kind-control-plane,.svc,.svc.cluster,.svc.cluster.local"
+            "noProxy": ".svc,.svc.cluster,.svc.cluster.local,127.0.0.0/8,169.254.169.254/32,fd00:ec2::254/128,${var.node_cidr},${var.pod_cidr},${var.service_cidr},${var.no_proxy}"
           }
         }
        }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -106,6 +106,12 @@ variable "http_proxy" {
   default     = ""
 }
 
+variable "no_proxy" {
+  description = "HTTP Proxy exception list."
+  type        = string
+  default     = ""
+}
+
 
 variable "worker_count" {
   description = "number of worker nodes in testcluster"


### PR DESCRIPTION
This addresses Issue #418 and introduces a new config variable
name no_proxy. It is trickled down in the same corners where http_proxy
is (when possible). A note to reviewers: When no "no_proxy" variable is
set (from terraforms side). The variable "no_proxy" ends with a trailing
"," (Because i did not spend the effort of adding another case for an empty
"no_proxy" variable in terraform). But this seems to work. Neither could
i notice that a program was confused by the trailing slash nor did any
program treat this as "bypass proxy for all requests".

Signed-off-by: Malte Münch <muench@b1-systems.de>
