### PR TITLE
Fix CLUSTER_NAME propagation for create_appcred.sh

### DIFF
--- a/terraform/files/bin/create_cluster.sh
+++ b/terraform/files/bin/create_cluster.sh
@@ -61,7 +61,7 @@ configure_proxy.sh $CLUSTERAPI_TEMPLATE || exit 1
 # Handle wanted OVN loadbalancer
 handle_ovn_lb.sh "$CLUSTER_NAME" || exit 1
 # Determine whether we need a new application credential
-create_appcred.sh || exit 1
+create_appcred.sh "$CLUSTER_NAME" || exit 1
 # Update OS_CLOUD
 #export OS_CLOUD=$PREFIX-$CLUSTER_NAME
 export OS_CLOUD=$(yq eval '.OPENSTACK_CLOUD' $CCCFG)


### PR DESCRIPTION
This solves a problem with the creation of a workload cluster other than `testcluster` as pointed out by @flyersa:
1. skip the step of creating a `testcluster`
2. create a new directory called `oshift`
3. copying *clusterctl.yml* from *cluster-defaults/* and adjusting worker/ctrl count
4. running `create_cluster.sh oshift`
```bash
ubuntu@capi-mgmtcluster:~ (⎈|kind-kind:N/A) [0]$ create_cluster.sh oshift
Switched to context "kind-kind".
> Cluster oshift does not exist. Creating a new cluster namespace...
namespace/oshift created
Context "kind-kind" modified.
Adding [docker.io/hosts.toml](http://docker.io/hosts.toml) to the KubeadmControlPlaneTemplate files
Adding [docker.io/hosts.toml](http://docker.io/hosts.toml) to the KubeadmConfigTemplate files
No HTTP_PROXY set, nothing to do, exiting.
Adding containerd proxy config to the KubeadmControlPlaneTemplate files
Adding containerd proxy config to the KubeadmConfigTemplate files
#Created AppCred a9a2921276cb4cde9c888f7bcc4e6265
sed: can't read /home/ubuntu/testcluster/cloud.conf: No such file or directory
Error: open /home/ubuntu/testcluster/clusterctl.yaml: no such file or directory
base64: /home/ubuntu/testcluster/cloud.conf: No such file or directory
#Info: Changing OPENSTACK_CLOUD from  to capi-testcluster
Error: stat /home/ubuntu/testcluster/clusterctl.yaml: no such file or directory
sed: can't read /home/ubuntu/testcluster/clusterctl.yaml: No such file or directory
Error: stat /home/ubuntu/testcluster/clusterctl.yaml: no such file or directory
Error: stat /home/ubuntu/testcluster/clusterctl.yaml: no such file or directory
Error: stat /home/ubuntu/testcluster/clusterctl.yaml: no such file or directory
```