### PR TITLE
Fix a markdown ReferenceError when building with docusaurus

### DIFF
--- a/doc/usage/migrate-to-kaas-v2.md
+++ b/doc/usage/migrate-to-kaas-v2.md
@@ -34,7 +34,7 @@ first, when you are on release < R6).
      make deploy-cso GIT_ACCESS_TOKEN=<github-access-token>
      make deploy-cspo GIT_ACCESS_TOKEN=<github-access-token>
      ```
-3. Export *${PREFIX}* and *${CLUSTER_NAME}*:
+3. Export `${PREFIX}` and `${CLUSTER_NAME}`:
    ```bash
    . ~/bin/cccfg.inc
    ```


### PR DESCRIPTION
Fixes the

    ReferenceError: PREFIX is not defined

error when the docs are built with docusaurus as part of the build pipeline in the https://github.com/SovereignCloudStack/docs repository. This error only appeared after #734 was merged, e.g., see [build log from 2024-05-24](https://github.com/SovereignCloudStack/docs/actions/runs/9183355112/job/25253911941#step:5:117).